### PR TITLE
Adding optional volume support to RDL

### DIFF
--- a/etc/reddwarf/reddwarf.conf.sample
+++ b/etc/reddwarf/reddwarf.conf.sample
@@ -52,6 +52,13 @@ nova_service_name = Compute Service
 # Config option for showing the IP address that nova doles out
 add_addresses = True
 
+# Config options for enabling volume service
+reddwarf_volume_support = False
+nova_volume_service_type = volume
+nova_volume_service_name = Volume Service
+device_path = /dev/vdb
+mount_point = /var/lib/mysql
+
 # ============ notifer queue kombu connection options ========================
 
 notifier_queue_hostname = localhost

--- a/etc/reddwarf/reddwarf.conf.sample
+++ b/etc/reddwarf/reddwarf.conf.sample
@@ -53,7 +53,7 @@ nova_service_name = Compute Service
 add_addresses = True
 
 # Config options for enabling volume service
-reddwarf_volume_support = False
+reddwarf_volume_support = True
 nova_volume_service_type = volume
 nova_volume_service_name = Volume Service
 device_path = /dev/vdb

--- a/etc/reddwarf/reddwarf.conf.test
+++ b/etc/reddwarf/reddwarf.conf.test
@@ -52,6 +52,16 @@ nova_region_name = RegionOne
 nova_service_type = compute
 nova_service_name = Compute Service
 
+# Config option for showing the IP address that nova doles out
+add_addresses = True
+
+# Config options for enabling volume service
+reddwarf_volume_support = False
+nova_volume_service_type = volume
+nova_volume_service_name = Volume Service
+device_path = /dev/vdb
+mount_point = /var/lib/mysql
+
 # ============ notifer queue kombu connection options ========================
 
 notifier_queue_hostname = localhost

--- a/etc/reddwarf/reddwarf.conf.test
+++ b/etc/reddwarf/reddwarf.conf.test
@@ -56,7 +56,7 @@ nova_service_name = Compute Service
 add_addresses = True
 
 # Config options for enabling volume service
-reddwarf_volume_support = False
+reddwarf_volume_support = True
 nova_volume_service_type = volume
 nova_volume_service_name = Volume Service
 device_path = /dev/vdb

--- a/reddwarf/common/exception.py
+++ b/reddwarf/common/exception.py
@@ -87,3 +87,8 @@ class UnprocessableEntity(ReddwarfError):
 
     message = _("Unable to process the contained request")
 
+
+class VolumeAttachmentsNotFound(NotFound):
+
+    message = _("Cannot find the volumes attached to compute "
+                "instance %(server_id)")

--- a/reddwarf/common/remote.py
+++ b/reddwarf/common/remote.py
@@ -19,7 +19,6 @@ from reddwarf.common import config
 from novaclient.v1_1.client import Client
 
 
-
 CONFIG = config.Config
 
 
@@ -40,8 +39,36 @@ def create_nova_client(context):
     PROXY_AUTH_URL = CONFIG.get('reddwarf_auth_url',
                                 'http://0.0.0.0:5000/v2.0')
     REGION_NAME = CONFIG.get('nova_region_name', 'RegionOne')
+
     SERVICE_TYPE = CONFIG.get('nova_service_type', 'compute')
     SERVICE_NAME = CONFIG.get('nova_service_name', 'Compute Service')
+
+    #TODO(cp16net) need to fix this proxy_tenant_id
+    client = Client(PROXY_ADMIN_USER, PROXY_ADMIN_PASS,
+        PROXY_ADMIN_TENANT_NAME, PROXY_AUTH_URL,
+        proxy_tenant_id=context.tenant,
+        proxy_token=context.auth_tok,
+        region_name=REGION_NAME,
+        service_type=SERVICE_TYPE,
+        service_name=SERVICE_NAME)
+    client.authenticate()
+    return client
+
+
+def create_nova_volume_client(context):
+    # Quite annoying but due to a paste config loading bug.
+    # TODO(hub-cap): talk to the openstack-common people about this
+    PROXY_ADMIN_USER = CONFIG.get('reddwarf_proxy_admin_user', 'admin')
+    PROXY_ADMIN_PASS = CONFIG.get('reddwarf_proxy_admin_pass',
+                                  '3de4922d8b6ac5a1aad9')
+    PROXY_ADMIN_TENANT_NAME = CONFIG.get('reddwarf_proxy_admin_tenant_name',
+                                         'admin')
+    PROXY_AUTH_URL = CONFIG.get('reddwarf_auth_url',
+                                'http://0.0.0.0:5000/v2.0')
+    REGION_NAME = CONFIG.get('nova_region_name', 'RegionOne')
+
+    SERVICE_TYPE = CONFIG.get('nova_volume_service_type', 'volume')
+    SERVICE_NAME = CONFIG.get('nova_volume_service_name', 'Volume Service')
 
     #TODO(cp16net) need to fix this proxy_tenant_id
     client = Client(PROXY_ADMIN_USER, PROXY_ADMIN_PASS,
@@ -59,6 +86,7 @@ if CONFIG.get("remote_implementation", "real") == "fake":
     # Override the functions above with fakes.
 
     from reddwarf.tests.fakes.nova import fake_create_nova_client
+    from reddwarf.tests.fakes.nova import fake_create_nova_volume_client
     from reddwarf.tests.fakes.guestagent import fake_create_guest_client
 
     def create_guest_client(context, id):
@@ -66,3 +94,6 @@ if CONFIG.get("remote_implementation", "real") == "fake":
 
     def create_nova_client(context):
         return fake_create_nova_client(context)
+
+    def create_nova_volume_client(context):
+        return fake_create_nova_volume_client(context)

--- a/reddwarf/common/utils.py
+++ b/reddwarf/common/utils.py
@@ -22,6 +22,7 @@ import logging
 import re
 import signal
 import sys
+import urlparse
 import uuid
 
 from eventlet import event
@@ -146,6 +147,7 @@ class LoopingCallDone(Exception):
 
     def __init__(self, retvalue=True):
         """:param retvalue: Value that LoopingCall.wait() should return."""
+        super(LoopingCallDone, self).__init__()
         self.retvalue = retvalue
 
 
@@ -208,10 +210,12 @@ def get_id_from_href(href):
 
 def execute_with_timeout(*args, **kwargs):
     time = kwargs.get('timeout', 30)
+
     def cb_timeout():
-       raise exception.ProcessExecutionError("Time out after waiting "
-           + str(time) + " seconds when running proc: " + str(args)
-           + str(kwargs))
+        msg = _("Time out after waiting"
+                " %(time)s seconds when running proc: %(args)s"
+                " %(kwargs)s") % locals()
+        raise exception.ProcessExecutionError(msg)
 
     timeout = Timeout(time)
     try:
@@ -220,8 +224,9 @@ def execute_with_timeout(*args, **kwargs):
         if t is not timeout:
             raise
         else:
-            raise exception.ProcessExecutionError("Time out after waiting "
-               + str(time) + " seconds when running proc: " + str(args)
-               + str(kwargs))
+            msg = _("Time out after waiting "
+                    "%(time)s seconds when running proc: %(args)s"
+                    " %(kwargs)s") % locals()
+            raise exception.ProcessExecutionError(msg)
     finally:
         timeout.cancel()

--- a/reddwarf/db/sqlalchemy/migrate_repo/versions/004_root_enabled.py
+++ b/reddwarf/db/sqlalchemy/migrate_repo/versions/004_root_enabled.py
@@ -35,6 +35,7 @@ root_enabled_history = Table('root_enabled_history', meta,
     Column('created', DateTime()),
     )
 
+
 def upgrade(migrate_engine):
     meta.bind = migrate_engine
     create_tables([root_enabled_history])

--- a/reddwarf/extensions/mgmt.py
+++ b/reddwarf/extensions/mgmt.py
@@ -52,5 +52,4 @@ class Mgmt(extensions.ExtensionsDescriptor):
             deserializer=wsgi.RequestDeserializer(),
             serializer=serializer)
         resources.append(resource)
-
         return resources

--- a/reddwarf/extensions/mgmt/service.py
+++ b/reddwarf/extensions/mgmt/service.py
@@ -56,4 +56,3 @@ class MgmtInstanceController(InstanceController):
             return wsgi.Result(str(e), 404)
         return wsgi.Result(views.InstanceView(server,
             add_addresses=self.add_addresses).data(), 200)
-

--- a/reddwarf/extensions/mgmt/views.py
+++ b/reddwarf/extensions/mgmt/views.py
@@ -45,6 +45,7 @@ class InstanceView(object):
             instance_dict['ip'] = ip
         return {"instance": instance_dict}
 
+
 class InstancesView(InstanceView):
 
     def __init__(self, instances, add_addresses=False):

--- a/reddwarf/extensions/mysql/models.py
+++ b/reddwarf/extensions/mysql/models.py
@@ -15,7 +15,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-"""Model classes that extend the instances functionality for MySQL instances.."""
+"""
+Model classes that extend the instances functionality for MySQL instances.
+"""
 
 import logging
 
@@ -111,7 +113,9 @@ class Root(object):
         root = create_guest_client(context, instance_id).enable_root()
         root_user = guest_models.MySQLUser()
         root_user.deserialize(root)
-        root_history = base_models.RootHistory.create(context, instance_id, user)
+        root_history = base_models.RootHistory.create(context,
+                                                      instance_id,
+                                                      user)
         return root_user
 
 

--- a/reddwarf/guestagent/api.py
+++ b/reddwarf/guestagent/api.py
@@ -122,12 +122,14 @@ class API(object):
         LOG.debug(_("Check diagnostics on Instance %s"), self.id)
         return self._call("get_diagnostics")
 
-    def prepare(self, memory_mb, databases, users):
+    def prepare(self, memory_mb, databases, users,
+                device_path='/dev/vdb', mount_point='/mnt/volume'):
         """Make an asynchronous call to prepare the guest
            as a database container"""
         LOG.debug(_("Sending the call to prepare the Guest"))
         self._cast_with_consumer("prepare", databases=databases,
-            memory_mb=memory_mb, users=users)
+            memory_mb=memory_mb, users=users, device_path=device_path,
+            mount_point=mount_point)
 
     def restart(self):
         """Restart the MySQL server."""
@@ -147,5 +149,5 @@ class API(object):
 
     def upgrade(self):
         """Make an asynchronous call to self upgrade the guest agent"""
-        LOG.debug(_("Sending an upgrade call to nova-guest %s"), topic)
+        LOG.debug(_("Sending an upgrade call to nova-guest"))
         self._cast_with_consumer("upgrade")

--- a/reddwarf/guestagent/dbaas.py
+++ b/reddwarf/guestagent/dbaas.py
@@ -411,7 +411,8 @@ class MySqlAdmin(object):
                 information_schema.schemata
             WHERE
                 schema_name not in
-                ('mysql', 'information_schema', 'lost+found')
+                ('mysql', 'information_schema',
+                 'lost+found', '#mysql50#lost+found')
             ORDER BY
                 schema_name ASC;
             ''')
@@ -503,7 +504,7 @@ class DBaaSAgent(object):
         # status end_mysql_install set with install_and_secure()
         app = MySqlApp(self.status)
         restart_mysql = False
-        if not device_path is None:
+        if device_path:
             VolumeHelper.format(device_path)
             if app.is_installed(pkg):
                 #stop and do not update database

--- a/reddwarf/guestagent/dbaas.py
+++ b/reddwarf/guestagent/dbaas.py
@@ -28,6 +28,7 @@ handles RPC calls relating to Platform specific operations.
 
 import logging
 import os
+import pexpect
 import re
 import sys
 import time
@@ -40,11 +41,14 @@ from sqlalchemy import interfaces
 from sqlalchemy.sql.expression import text
 
 from reddwarf import db
+from reddwarf.common.exception import GuestError
 from reddwarf.common.exception import ProcessExecutionError
 from reddwarf.common import config
 from reddwarf.common import utils
 from reddwarf.guestagent.db import models
+from reddwarf.guestagent.volume import VolumeHelper
 from reddwarf.instance import models as rd_models
+
 
 ADMIN_USER_NAME = "os_admin"
 LOG = logging.getLogger(__name__)
@@ -60,6 +64,8 @@ FINAL_MYCNF = "/var/lib/mysql/my.cnf"
 TMP_MYCNF = "/tmp/my.cnf.tmp"
 DBAAS_MYCNF = "/etc/dbaas/my.cnf/my.cnf.%dM"
 MYSQL_BASE_DIR = "/var/lib/mysql"
+
+CONFIG = config.Config
 
 
 def generate_random_password():
@@ -140,7 +146,6 @@ class MySqlAppStatus(object):
         self.status = self._load_status()
         self.restart_mode = False
 
-
     def begin_mysql_install(self):
         """Called right before MySQL is prepared."""
         self.set_status(rd_models.ServiceStatuses.BUILDING)
@@ -176,8 +181,8 @@ class MySqlAppStatus(object):
         except ProcessExecutionError as e:
             LOG.error("Process execution ")
             try:
-                out, err = utils.execute_with_timeout("/bin/ps", "-C", "mysqld",
-                                                      "h")
+                out, err = utils.execute_with_timeout("/bin/ps", "-C",
+                                                      "mysqld", "h")
                 pid = out.split()[0]
                 # TODO(rnirmal): Need to create new statuses for instances
                 # where the mysql service is up, but unresponsive
@@ -227,7 +232,6 @@ class MySqlAppStatus(object):
         db_status.set_status(status)
         db_status.save()
         self.status = status
-
 
     def update(self):
         """Find and report status of MySQL on this machine.
@@ -488,13 +492,33 @@ class DBaaSAgent(object):
     def is_root_enabled(self):
         return MySqlAdmin().is_root_enabled()
 
-    def prepare(self, databases, memory_mb, users):
+    def prepare(self, databases, memory_mb, users, device_path=None,
+                mount_point=None):
         """Makes ready DBAAS on a Guest container."""
         from reddwarf.guestagent.pkg import PkgAgent
         if not isinstance(self, PkgAgent):
             raise TypeError("This must also be an instance of Pkg agent.")
         pkg = self  # Python cast.
+        self.status.begin_mysql_install()
+        # status end_mysql_install set with install_and_secure()
         app = MySqlApp(self.status)
+        restart_mysql = False
+        if not device_path is None:
+            VolumeHelper.format(device_path)
+            if app.is_installed(pkg):
+                #stop and do not update database
+                app.stop_mysql()
+                restart_mysql = True
+                #rsync exiting data
+                VolumeHelper.migrate_data(device_path, MYSQL_BASE_DIR)
+            #mount the volume
+            VolumeHelper.mount(device_path, mount_point)
+            #TODO(cp16net) need to update the fstab here so that on a
+            # restart the volume will be mounted automatically again
+            LOG.debug(_("Mounted the volume."))
+            #check mysql was installed and stopped
+            if restart_mysql:
+                app.start_mysql()
         app.install_and_secure(pkg, memory_mb)
         LOG.info("Creating initial databases and users following successful "
                  "prepare.")
@@ -536,11 +560,12 @@ class MySqlApp(object):
     """Prepares DBaaS on a Guest container."""
 
     TIME_OUT = 1000
+    MYSQL_PACKAGE_VERSION = "mysql-server-5.1"
 
     def __init__(self, status):
         """ By default login with root no password for initial setup. """
-        self.state_change_wait_time = config.Config.get(
-            'state_change_wait_time', 2 * 60)
+        self.state_change_wait_time = int(config.Config.get(
+            'state_change_wait_time', 2 * 60))
         self.status = status
 
     def _create_admin_user(self, client, password):
@@ -586,21 +611,21 @@ class MySqlApp(object):
             self._remove_remote_root_access(client)
             self._create_admin_user(client, admin_password)
 
-        self._internal_stop_mysql()
+        self.stop_mysql()
         self._write_mycnf(pkg, memory_mb, admin_password)
-        self._start_mysql()
+        self.start_mysql()
 
         self.status.end_install_or_restart()
-        LOG.info(_("Dbaas preparation complete."))
+        LOG.info(_("Dbaas install_and_secure complete."))
 
     def _install_mysql(self, pkg):
         """Install mysql server. The current version is 5.1"""
         LOG.debug(_("Installing mysql server"))
-        pkg.pkg_install("mysql-server-5.1", self.TIME_OUT)
+        pkg.pkg_install(self.MYSQL_PACKAGE_VERSION, self.TIME_OUT)
         LOG.debug(_("Finished installing mysql server"))
         #TODO(rnirmal): Add checks to make sure the package got installed
 
-    def _internal_stop_mysql(self, update_db=False):
+    def stop_mysql(self, update_db=False):
         LOG.info(_("Stopping mysql..."))
         utils.execute_with_timeout("sudo", "/etc/init.d/mysql", "stop")
         if not self.status.wait_for_real_status_to_change_to(
@@ -623,8 +648,8 @@ class MySqlApp(object):
     def restart(self):
         try:
             self.status.begin_mysql_restart()
-            self._internal_stop_mysql()
-            self._start_mysql()
+            self.stop_mysql()
+            self.start_mysql()
         finally:
             self.status.end_install_or_restart()
 
@@ -702,8 +727,7 @@ class MySqlApp(object):
         utils.execute_with_timeout("sudo", "ln", "-s", FINAL_MYCNF, ORIG_MYCNF)
         self.wipe_ib_logfiles()
 
-
-    def _start_mysql(self, update_db=False):
+    def start_mysql(self, update_db=False):
         LOG.info(_("Starting mysql..."))
         # This is the site of all the trouble in the restart tests.
         # Essentially what happens is thaty mysql start fails, but does not
@@ -736,8 +760,10 @@ class MySqlApp(object):
                         "MySQL state == %s!") % self.status)
             raise RuntimeError("MySQL not stopped.")
         LOG.info(_("Initiating config."))
-        self._write_mycnf(pkg, update_memory_mb, None)
-        self._start_mysql(True)
+        self._write_mycnf(pkg, updated_memory_mb, None)
+        self.start_mysql(True)
 
-    def stop_mysql(self):
-        self._internal_stop_mysql(True)
+    def is_installed(self, pkg):
+        #(cp16net) could raise an exception, does it need to be handled here?
+        version = pkg.pkg_version(self.MYSQL_PACKAGE_VERSION)
+        return not version is None

--- a/reddwarf/guestagent/manager.py
+++ b/reddwarf/guestagent/manager.py
@@ -44,8 +44,9 @@ class GuestManager(service.Manager):
     """Manages the tasks within a Guest VM."""
 
     def __init__(self, guest_drivers=None, *args, **kwargs):
+        service_type = CONFIG.get('service_type')
         try:
-            service_impl = GUEST_SERVICES[CONFIG.get('service_type')]
+            service_impl = GUEST_SERVICES[service_type]
         except KeyError as e:
             LOG.error(_("Could not create guest, no impl for key - %s") %
                      service_type)

--- a/reddwarf/guestagent/volume.py
+++ b/reddwarf/guestagent/volume.py
@@ -1,0 +1,129 @@
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+
+# Copyright (c) 2011 OpenStack, LLC.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import logging
+import os
+import pexpect
+
+from reddwarf.common import config
+from reddwarf.common import utils
+from reddwarf.common.exception import GuestError
+from reddwarf.common.exception import ProcessExecutionError
+
+TMP_MOUNT_POINT = "/mnt/volume"
+
+LOG = logging.getLogger(__name__)
+CONFIG = config.Config
+
+
+class VolumeHelper(object):
+
+    @staticmethod
+    def _has_volume_device(device_path):
+        return not device_path is None
+
+    @staticmethod
+    def migrate_data(device_path, mysql_base):
+        """ Synchronize the data from the mysql directory to the new volume """
+        utils.execute("sudo", "mkdir", "-p", TMP_MOUNT_POINT)
+        VolumeHelper.mount(device_path, TMP_MOUNT_POINT)
+        if not mysql_base[-1] == '/':
+            mysql_base = "%s/" % mysql_base
+        utils.execute("sudo", "rsync", "--safe-links", "--perms",
+                      "--recursive", "--owner", "--group", "--xattrs",
+                      "--sparse", mysql_base, TMP_MOUNT_POINT)
+        VolumeHelper.unmount(device_path)
+
+    @staticmethod
+    def _check_device_exists(device_path):
+        """Check that the device path exists.
+
+        Verify that the device path has actually been created and can report
+        it's size, only then can it be available for formatting, retry
+        num_tries to account for the time lag.
+        """
+        try:
+            num_tries = CONFIG.get('num_tries', 3)
+            utils.execute('sudo', 'blockdev', '--getsize64', device_path,
+                          attempts=num_tries)
+        except ProcessExecutionError:
+            raise GuestError("InvalidDevicePath(path=%s)" % device_path)
+
+    @staticmethod
+    def _check_format(device_path):
+        """Checks that an unmounted volume is formatted."""
+        child = pexpect.spawn("sudo dumpe2fs %s" % device_path)
+        try:
+            i = child.expect(['has_journal', 'Wrong magic number'])
+            if i == 0:
+                return
+            volume_fstype = CONFIG.get('volume_fstype', 'ext3')
+            raise IOError('Device path at %s did not seem to be %s.' %
+                          (device_path, volume_fstype))
+        except pexpect.EOF:
+            raise IOError("Volume was not formatted.")
+        child.expect(pexpect.EOF)
+
+    @staticmethod
+    def _format(device_path):
+        """Calls mkfs to format the device at device_path."""
+        volume_fstype = CONFIG.get('volume_fstype', 'ext3')
+        format_options = CONFIG.get('format_options', '-m 5')
+        cmd = "sudo mkfs -t %s %s %s" % (volume_fstype,
+                                         format_options, device_path)
+        volume_format_timeout = CONFIG.get('volume_format_timeout', 120)
+        child = pexpect.spawn(cmd, timeout=volume_format_timeout)
+        # child.expect("(y,n)")
+        # child.sendline('y')
+        child.expect(pexpect.EOF)
+
+    @staticmethod
+    def format(device_path):
+        """Formats the device at device_path and checks the filesystem."""
+        VolumeHelper._check_device_exists(device_path)
+        VolumeHelper._format(device_path)
+        VolumeHelper._check_format(device_path)
+
+    @staticmethod
+    def mount(device_path, mount_point):
+        if not os.path.exists(mount_point):
+            os.makedirs(mount_point)
+        volume_fstype = CONFIG.get('volume_fstype', 'ext3')
+        mount_options = CONFIG.get('mount_options', 'noatime')
+        cmd = "sudo mount -t %s -o %s %s %s" % (volume_fstype,
+                                                mount_options,
+                                                device_path, mount_point)
+        child = pexpect.spawn(cmd)
+        child.expect(pexpect.EOF)
+
+    @staticmethod
+    def unmount(mount_point):
+        if os.path.exists(mount_point):
+            cmd = "sudo umount %s" % mount_point
+            child = pexpect.spawn(cmd)
+            child.expect(pexpect.EOF)
+
+    @staticmethod
+    def resize_fs(device_path):
+        """Resize the filesystem on the specified device"""
+        VolumeHelper._check_device_exists(device_path)
+        try:
+            utils.execute("sudo", "resize2fs", device_path)
+        except ProcessExecutionError as err:
+            LOG.error(err)
+            raise GuestError("Error resizing the filesystem: %s"
+                                       % device_path)

--- a/reddwarf/instance/models.py
+++ b/reddwarf/instance/models.py
@@ -690,7 +690,8 @@ class RootHistory(ModelBase):
         self.created = utils.utcnow()
 
     def save(self):
-        LOG.debug(_("Saving %s: %s") % (self.__class__.__name__, self.__dict__))
+        LOG.debug(_("Saving %s: %s") % (self.__class__.__name__,
+                                        self.__dict__))
         return db.db_api.save(self)
 
     @classmethod

--- a/reddwarf/instance/models.py
+++ b/reddwarf/instance/models.py
@@ -64,15 +64,14 @@ def load_volumes(context, server_id, client=None):
         volume_client = create_nova_volume_client(context)
         try:
             volumes = []
-            if utils.bool_from_string(volume_support):
-                volumes_info = client.volumes.get_server_volumes(server_id)
-                volume_ids = [attachments.volumeId for attachments in
-                              volumes_info]
-                for volume_id in volume_ids:
-                    volume_info = volume_client.volumes.get(volume_id)
-                    volume = {'id': volume_info.id,
-                              'size': volume_info.size}
-                    volumes.append(volume)
+            volumes_info = client.volumes.get_server_volumes(server_id)
+            volume_ids = [attachments.volumeId for attachments in
+                          volumes_info]
+            for volume_id in volume_ids:
+                volume_info = volume_client.volumes.get(volume_id)
+                volume = {'id': volume_info.id,
+                          'size': volume_info.size}
+                volumes.append(volume)
         except nova_exceptions.NotFound, e:
             LOG.debug("Could not find nova server_id(%s)" % server_id)
             raise rd_exceptions.VolumeAttachmentsNotFound(server_id=server_id)
@@ -174,11 +173,11 @@ class Instance(object):
     @classmethod
     def _create_volume(cls, context, db_info, volume_size):
         volume_support = config.Config.get("reddwarf_volume_support", 'False')
-        LOG.debug(_("Volume support = %s") % volume_support)
+        LOG.debug(_("reddwarf volume support = %s") % volume_support)
         if utils.bool_from_string(volume_support):
             LOG.debug(_("Starting to create the volume for the instance"))
             volume_client = create_nova_volume_client(context)
-            volume_desc = ("mysql volume for %s" % context.tenant)
+            volume_desc = ("mysql volume for %s" % db_info.id)
             volume_ref = volume_client.volumes.create(
                                         volume_size,
                                         display_name="mysql-%s" % db_info.id,

--- a/reddwarf/instance/service.py
+++ b/reddwarf/instance/service.py
@@ -204,7 +204,8 @@ class InstanceController(BaseController):
         # TODO(cp16net): need to set the return code correctly
         # Adding the root history, if it exists.
         history = models.RootHistory.load(context=context, instance_id=id)
-        return wsgi.Result(views.InstanceDetailView(server, roothistory=history,
+        return wsgi.Result(views.InstanceDetailView(server,
+                           roothistory=history,
                            add_addresses=self.add_addresses,
                            add_volumes=self.add_volumes).data(), 200)
 

--- a/reddwarf/instance/service.py
+++ b/reddwarf/instance/service.py
@@ -56,7 +56,10 @@ class BaseController(wsgi.Controller):
         }
 
     def __init__(self):
-        self.add_addresses = config.Config.get('add_addresses', False)
+        self.add_addresses = utils.bool_from_string(
+                        config.Config.get('add_addresses', 'False'))
+        self.add_volumes = utils.bool_from_string(
+                        config.Config.get('reddwarf_volume_support', 'False'))
         pass
 
     def _extract_required_params(self, params, model_name):
@@ -166,7 +169,7 @@ class InstanceController(BaseController):
     def detail(self, req, tenant_id):
         """Return all instances."""
         LOG.info(_("req : '%s'\n\n") % req)
-        LOG.info(_("Detailing a database instance for tenant '%s'") % tenant_id)
+        LOG.info(_("Detailing database instance for tenant '%s'") % tenant_id)
         #TODO(cp16net) return a detailed list instead of index
         return self.index(req, tenant_id, detailed=True)
 
@@ -180,7 +183,8 @@ class InstanceController(BaseController):
         view_cls = views.InstancesDetailView if detailed \
                                              else views.InstancesView
         return wsgi.Result(view_cls(servers,
-                           add_addresses=self.add_addresses).data(), 200)
+                           add_addresses=self.add_addresses,
+                           add_volumes=self.add_volumes).data(), 200)
 
     def show(self, req, tenant_id, id):
         """Return a single instance."""
@@ -201,7 +205,8 @@ class InstanceController(BaseController):
         # Adding the root history, if it exists.
         history = models.RootHistory.load(context=context, instance_id=id)
         return wsgi.Result(views.InstanceDetailView(server, roothistory=history,
-                           add_addresses=self.add_addresses).data(), 200)
+                           add_addresses=self.add_addresses,
+                           add_volumes=self.add_volumes).data(), 200)
 
     def delete(self, req, tenant_id, id):
         """Delete a single instance."""
@@ -252,10 +257,13 @@ class InstanceController(BaseController):
         databases = body['instance'].get('databases')
         if databases is None:
             databases = []
+        volume_size = body['instance']['volume']['size']
         instance = models.Instance.create(context, name, flavor_ref,
-                                          image_id, databases, service_type)
+                                          image_id, databases,
+                                          service_type, volume_size)
 
-        return wsgi.Result(views.InstanceDetailView(instance).data(), 200)
+        return wsgi.Result(views.InstanceDetailView(instance,
+                                  add_volumes=self.add_volumes).data(), 200)
 
     @staticmethod
     def _validate_body_not_empty(body):
@@ -295,12 +303,12 @@ class InstanceController(BaseController):
             body['instance']
             body['instance']['flavorRef']
             # TODO(cp16net) add in volume to the mix
-#            volume_size = body['instance']['volume']['size']
+            volume_size = body['instance']['volume']['size']
         except KeyError as e:
             LOG.error(_("Create Instance Required field(s) - %s") % e)
             raise rd_exceptions.ReddwarfError("Required element/key - %s "
                                        "was not specified" % e)
-#        Instance._validate_volume_size(volume_size)
+        InstanceController._validate_volume_size(volume_size)
 
     @staticmethod
     def _validate_resize_instance(body):

--- a/reddwarf/instance/views.py
+++ b/reddwarf/instance/views.py
@@ -15,6 +15,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import logging
+LOG = logging.getLogger(__name__)
+
 
 def get_ip_address(addresses):
     if addresses is not None and \
@@ -23,14 +26,22 @@ def get_ip_address(addresses):
         return [addr.get('addr') for addr in addresses['private']]
 
 
+def get_volumes(volumes):
+    LOG.debug("volumes - %s" % volumes)
+    if volumes is not None and len(volumes) > 0:
+        return {'size': volumes[0].get('size')}
+
+
 class InstanceView(object):
 
-    def __init__(self, instance, add_addresses=False):
+    def __init__(self, instance, add_addresses=False, add_volumes=False):
         self.instance = instance
         self.add_addresses = add_addresses
+        self.add_volumes = add_volumes
 
     def data(self):
         ip = get_ip_address(self.instance.addresses)
+        volumes = get_volumes(self.instance.volumes)
         instance_dict = {
             "id": self.instance.id,
             "name": self.instance.name,
@@ -39,6 +50,9 @@ class InstanceView(object):
         }
         if self.add_addresses and ip is not None and len(ip) > 0:
             instance_dict['ip'] = ip
+        if self.add_volumes and volumes is not None:
+            instance_dict['volume'] = volumes
+        LOG.debug(instance_dict)
         return {"instance": instance_dict}
 
 
@@ -61,9 +75,10 @@ class InstanceDetailView(InstanceView):
 
 class InstancesView(object):
 
-    def __init__(self, instances, add_addresses=False):
+    def __init__(self, instances, add_addresses=False, add_volumes=False):
         self.instances = instances
         self.add_addresses = add_addresses
+        self.add_volumes = add_volumes
 
     def data(self):
         data = []
@@ -81,4 +96,5 @@ class InstancesDetailView(InstancesView):
 
     def data_for_instance(self, instance):
         return InstanceDetailView(instance,
-                                  self.add_addresses).data()['instance']
+                                  self.add_addresses,
+                                  self.add_volumes).data()['instance']

--- a/reddwarf/instance/views.py
+++ b/reddwarf/instance/views.py
@@ -58,8 +58,11 @@ class InstanceView(object):
 
 class InstanceDetailView(InstanceView):
 
-    def __init__(self, instance, add_addresses=False, roothistory=None):
-        super(InstanceDetailView, self).__init__(instance, add_addresses)
+    def __init__(self, instance, roothistory=None, add_addresses=False,
+                 add_volumes=False):
+        super(InstanceDetailView, self).__init__(instance,
+                                                 add_addresses=add_addresses,
+                                                 add_volumes=add_volumes)
         self.roothistory = roothistory
 
     def data(self):
@@ -96,5 +99,5 @@ class InstancesDetailView(InstancesView):
 
     def data_for_instance(self, instance):
         return InstanceDetailView(instance,
-                                  self.add_addresses,
-                                  self.add_volumes).data()['instance']
+                               add_addresses=self.add_addresses,
+                               add_volumes=self.add_volumes).data()['instance']

--- a/reddwarf/tests/fakes/guestagent.py
+++ b/reddwarf/tests/fakes/guestagent.py
@@ -69,9 +69,11 @@ class FakeGuest(object):
     def list_users(self):
         return [self.users[name] for name in self.users]
 
-    def prepare(self, memory_mb, databases, users):
+    def prepare(self, databases, memory_mb, users, device_path=None,
+                mount_point=None):
         from reddwarf.instance.models import InstanceServiceStatus
         from reddwarf.instance.models import ServiceStatuses
+
         def update_db():
             status = InstanceServiceStatus.find_by(instance_id=self.id)
             status.status = ServiceStatuses.RUNNING
@@ -87,6 +89,7 @@ class FakeGuest(object):
     def start_mysql_with_conf_changes(self, updated_memory_size):
         from reddwarf.instance.models import InstanceServiceStatus
         from reddwarf.instance.models import ServiceStatuses
+
         def update_db():
             status = InstanceServiceStatus.find_by(instance_id=self.id)
             status.status = ServiceStatuses.RUNNING
@@ -96,6 +99,7 @@ class FakeGuest(object):
     def stop_mysql(self):
         from reddwarf.instance.models import InstanceServiceStatus
         from reddwarf.instance.models import ServiceStatuses
+
         def update_db():
             status = InstanceServiceStatus.find_by(instance_id=self.id)
             status.status = ServiceStatuses.SHUTDOWN

--- a/reddwarf/tests/fakes/nova.py
+++ b/reddwarf/tests/fakes/nova.py
@@ -96,7 +96,7 @@ class FakeServer(object):
 
     @property
     def addresses(self):
-        return {"private":[{"addr":"123.123.123.123"}]}
+        return {"private": [{"addr":"123.123.123.123"}]}
 
     def delete(self):
         self.schedule_status = []
@@ -193,4 +193,8 @@ class FakeClient(object):
 
 
 def fake_create_nova_client(context):
+    return FakeClient(context)
+
+
+def fake_create_nova_volume_client(context):
     return FakeClient(context)

--- a/reddwarf/tests/fakes/nova.py
+++ b/reddwarf/tests/fakes/nova.py
@@ -84,7 +84,8 @@ class FakeFlavors(object):
 
 class FakeServer(object):
 
-    def __init__(self, parent, owner, id, name, image_id, flavor_ref):
+    def __init__(self, parent, owner, id, name, image_id, flavor_ref,
+                 block_device_mapping):
         self.owner = owner  # This is a context.
         self.id = id
         self.parent = parent
@@ -93,6 +94,8 @@ class FakeServer(object):
         self.flavor_ref = flavor_ref
         self.events = EventSimulator()
         self.schedule_status("BUILD", 0.0)
+        LOG.debug("block_device_mapping = %s" % block_device_mapping)
+        self.block_device_mapping = block_device_mapping
 
     @property
     def addresses(self):
@@ -153,17 +156,20 @@ class FakeServers(object):
         return self.context.is_admin or \
                server.owner.tenant == self.context.tenant
 
-    def create(self, name, image_id, flavor_ref, files):
+    def create(self, name, image_id, flavor_ref, files, block_device_mapping):
         id = "FAKE_%d" % self.next_id
         self.next_id += 1
-        server = FakeServer(self, self.context, id, name, image_id, flavor_ref)
+        server = FakeServer(self, self.context, id, name, image_id, flavor_ref,
+                            block_device_mapping)
         self.db[id] = server
         server.schedule_status("ACTIVE", 1)
+        LOG.info("FAKE_SERVERS_DB : %s" % str(FAKE_SERVERS_DB))
         return server
 
     def get(self, id):
         if id not in self.db:
-            LOG.error("Couldn't find id %s, collection=%s" % (id, self.db))
+            LOG.error("Couldn't find server id %s, collection=%s" % (id,
+                                                                     self.db))
             raise nova_exceptions.NotFound(404, "Not found")
         else:
             if self.can_see(id):
@@ -181,6 +187,25 @@ class FakeServers(object):
         self.events.add_event(time_from_now, delete_server)
 
 
+class FakeServerVolumes(object):
+
+    def __init__(self, context):
+        self.context = context
+
+    def get_server_volumes(self, server_id):
+        class ServerVolumes(object):
+            def __init__(self, block_device_mapping):
+                LOG.debug("block_device_mapping = %s" % block_device_mapping)
+                device = block_device_mapping['vdb']
+                (self.volumeId,
+                    self.type,
+                    self.size,
+                    self.delete_on_terminate) = device.split(":")
+        fake_servers = FakeServers(self.context, FLAVORS)
+        server = fake_servers.get(server_id)
+        return [ServerVolumes(server.block_device_mapping)]
+
+
 FLAVORS = FakeFlavors()
 
 
@@ -190,11 +215,87 @@ class FakeClient(object):
         self.context = context
         self.flavors = FLAVORS
         self.servers = FakeServers(context, self.flavors)
+        self.volumes = FakeServerVolumes(context)
 
 
 def fake_create_nova_client(context):
     return FakeClient(context)
 
 
+class FakeVolume(object):
+
+    def __init__(self, parent, owner, id, size, display_name,
+                 display_description):
+        self.parent = parent
+        self.owner = owner  # This is a context.
+        self.id = id
+        self.size = size
+        self.display_name = display_name
+        self.display_description = display_description
+        self.events = EventSimulator()
+        self.schedule_status("BUILD", 0.0)
+
+    def __repr__(self):
+        return ("FakeVolume(id=%s, size=%s, "
+               "display_name=%s, display_description=%s)") % (self.id,
+               self.size, self.display_name, self.display_description)
+
+    def schedule_status(self, new_status, time_from_now):
+        """Makes a new status take effect at the given time."""
+        def set_status():
+            self._current_status = new_status
+        self.events.add_event(time_from_now, set_status)
+
+    @property
+    def status(self):
+        return self._current_status
+
+
+FAKE_VOLUMES_DB = {}
+
+
+class FakeVolumes(object):
+
+    def __init__(self, context):
+        self.context = context
+        self.db = FAKE_VOLUMES_DB
+        self.next_id = 10
+        self.events = EventSimulator()
+
+    def can_see(self, id):
+        """Can this FakeVolumes, with its context, see some resource?"""
+        server = self.db[id]
+        return self.context.is_admin or \
+               server.owner.tenant == self.context.tenant
+
+    def get(self, id):
+        if id not in self.db:
+            LOG.error("Couldn't find volume id %s, collection=%s" % (id,
+                                                                     self.db))
+            raise nova_exceptions.NotFound(404, "Not found")
+        else:
+            if self.can_see(id):
+                return self.db[id]
+            else:
+                raise nova_exceptions.NotFound(404, "Bad permissions")
+
+    def create(self, size, display_name=None, display_description=None):
+        id = "FAKE_VOL_%d" % self.next_id
+        self.next_id += 1
+        volume = FakeVolume(self, self.context, id, size, display_name,
+                            display_description)
+        self.db[id] = volume
+        volume.schedule_status("available", 2)
+        LOG.info("FAKE_VOLUMES_DB : %s" % FAKE_VOLUMES_DB)
+        return volume
+
+
+class FakeVolumeClient(object):
+
+    def __init__(self, context):
+        self.context = context
+        self.volumes = FakeVolumes(context)
+
+
 def fake_create_nova_volume_client(context):
-    return FakeClient(context)
+    return FakeVolumeClient(context)


### PR DESCRIPTION
- Allowing a user to add a volume to the instance on create api call
- added some helper code to make sure the mysql service is up 
- add a config value to turn on volume support
- moving around the lines to be dependent on volume support
- trying to stop volume support
- fixes with the merge
- imported and raised exceptions in guest correctly
- fixed the config get values as boolean and not just the string
- deleting the serivce status entry on delete of the instance so that the
  guest can not update the instance to active again.
- made the create and update times saved correctly for an instance
- check if mysql is already installed in the guest
- clean up instance model
- using _(i8n)
- adding the populate databases back in
- pep8 compliance

**after comments**
- updated apt get version method
- moved the volumeHelper class to a new module
- made the start/stop mysql methods public
- created a method to create volume for instances and readability
- created a new client for volume calls
- added the volume and size to the create/list/show instance api calls
