### PR TITLE
Resize flavor

### DIFF
--- a/reddwarf/common/exception.py
+++ b/reddwarf/common/exception.py
@@ -108,3 +108,8 @@ class VolumeAttachmentsNotFound(NotFound):
 
     message = _("Cannot find the volumes attached to compute "
                 "instance %(server_id)")
+
+
+class VolumeCreationFailure(ReddwarfError):
+
+    message = _("Failed to create a volume in Nova.")

--- a/reddwarf/common/exception.py
+++ b/reddwarf/common/exception.py
@@ -80,7 +80,7 @@ class OverLimit(ReddwarfError):
 class GuestError(ReddwarfError):
 
     message = _("An error occurred communicating with the guest: "
-                "%(original_message).")
+                "%(original_message)s.")
 
 
 class BadRequest(ReddwarfError):
@@ -97,6 +97,11 @@ class MissingKey(BadRequest):
 class UnprocessableEntity(ReddwarfError):
 
     message = _("Unable to process the contained request")
+
+
+class CannotResizeToSameSize(ReddwarfError):
+
+    message = _("When resizing, instances must change size!")
 
 
 class VolumeAttachmentsNotFound(NotFound):

--- a/reddwarf/common/exception.py
+++ b/reddwarf/common/exception.py
@@ -58,12 +58,23 @@ class NotFound(ReddwarfError):
     message = _("Resource %(uuid)s cannot be found")
 
 
+class FlavorNotFound(ReddwarfError):
+
+    message = _("Resource %(uuid)s cannot be found")
+
+
 class ComputeInstanceNotFound(NotFound):
 
     internal_message = _("Cannot find compute instance %(server_id)s for "
                          "instance %(instance_id)s.")
 
     message = _("Resource %(instance_id)s can not be retrieved.")
+
+
+class OverLimit(ReddwarfError):
+
+    internal_message = _("The server rejected the request due to its size or "
+                         "rate.")
 
 
 class GuestError(ReddwarfError):

--- a/reddwarf/common/utils.py
+++ b/reddwarf/common/utils.py
@@ -42,6 +42,19 @@ execute = openstack_utils.execute
 isotime = openstack_utils.isotime
 
 
+def create_method_args_string(*args, **kwargs):
+    """Returns a string representation of args and keyword args.
+
+    I.e. for args=1,2,3 and kwargs={'a':4, 'b':5} you'd get: "1,2,3,a=4,b=5"
+    """
+    # While %s turns a var into a string but in some rare cases explicit
+    # str() is less likely to raise an exception.
+    arg_strs = [repr(arg) for arg in args]
+    arg_strs += ['%s=%s' % (repr(key), repr(value))
+                 for (key, value) in kwargs.items()]
+    return ','.join(arg_strs)
+
+
 def stringify_keys(dictionary):
     if dictionary is None:
         return None

--- a/reddwarf/common/utils.py
+++ b/reddwarf/common/utils.py
@@ -48,11 +48,11 @@ def create_method_args_string(*args, **kwargs):
     I.e. for args=1,2,3 and kwargs={'a':4, 'b':5} you'd get: "1,2,3,a=4,b=5"
     """
     # While %s turns a var into a string but in some rare cases explicit
-    # str() is less likely to raise an exception.
+    # repr() is less likely to raise an exception.
     arg_strs = [repr(arg) for arg in args]
     arg_strs += ['%s=%s' % (repr(key), repr(value))
                  for (key, value) in kwargs.items()]
-    return ','.join(arg_strs)
+    return ', '.join(arg_strs)
 
 
 def stringify_keys(dictionary):

--- a/reddwarf/db/sqlalchemy/migrate_repo/versions/001_base_schema.py
+++ b/reddwarf/db/sqlalchemy/migrate_repo/versions/001_base_schema.py
@@ -40,7 +40,8 @@ instances = Table('instances', meta,
         Column('compute_instance_id', String(36)),
         Column('task_id', Integer()),
         Column('task_description', String(32)),
-        Column('task_start_time', DateTime()))
+        Column('task_start_time', DateTime()),
+        Column('volume_id', String(36)))
 
 
 def upgrade(migrate_engine):

--- a/reddwarf/flavor/views.py
+++ b/reddwarf/flavor/views.py
@@ -40,7 +40,7 @@ class FlavorView(object):
             detailed = '/detail'
             splitpath.pop(-1)
         flavorid = self.flavor.id
-        if splitpath[-1] == flavorid:
+        if str(splitpath[-1]) == str(flavorid):
             splitpath.pop(-1)
         href_template = "%(scheme)s://%(endpoint)s%(path)s/%(flavorid)s"
         for link in self.flavor.links:

--- a/reddwarf/guestagent/dbaas.py
+++ b/reddwarf/guestagent/dbaas.py
@@ -646,6 +646,14 @@ class MySqlApp(object):
                            AND Host!='localhost';""")
         client.execute(t)
 
+    def restart_with_sync(self, migration_function):
+        """Restarts MySQL, doing some action in-between.
+
+        Does not update the database."""
+        self._internal_stop_mysql()
+        migration_function()
+        self._start_mysql()
+
     def restart(self):
         try:
             self.status.begin_mysql_restart()

--- a/reddwarf/guestagent/dbaas.py
+++ b/reddwarf/guestagent/dbaas.py
@@ -46,7 +46,7 @@ from reddwarf.common.exception import ProcessExecutionError
 from reddwarf.common import config
 from reddwarf.common import utils
 from reddwarf.guestagent.db import models
-from reddwarf.guestagent.volume import VolumeHelper
+from reddwarf.guestagent.volume import VolumeDevice
 from reddwarf.instance import models as rd_models
 
 
@@ -503,17 +503,16 @@ class DBaaSAgent(object):
         app = MySqlApp(self.status)
         restart_mysql = False
         if device_path:
-            VolumeHelper.format(device_path)
+            device = VolumeDevice(device_path)
+            device.format()
             if app.is_installed(pkg):
                 #stop and do not update database
                 app.stop_mysql()
                 restart_mysql = True
                 #rsync exiting data
-                VolumeHelper.migrate_data(device_path, MYSQL_BASE_DIR)
+                device.migrate_data(MYSQL_BASE_DIR)
             #mount the volume
-            VolumeHelper.mount(device_path, mount_point)
-            #TODO(cp16net) need to update the fstab here so that on a
-            # restart the volume will be mounted automatically again
+            device.mount(mount_point)
             LOG.debug(_("Mounted the volume."))
             #check mysql was installed and stopped
             if restart_mysql:

--- a/reddwarf/instance/models.py
+++ b/reddwarf/instance/models.py
@@ -43,7 +43,7 @@ CONFIG = config.Config
 LOG = logging.getLogger(__name__)
 
 
-def load_server(context, instance_id, server_id):
+def load_server_with_volumes(context, instance_id, server_id):
     """Loads a server or raises an exception."""
     client = create_nova_client(context)
     try:
@@ -168,8 +168,8 @@ class Instance(object):
             db_info = DBInstance.find_by(id=id)
         except rd_exceptions.NotFound:
             raise rd_exceptions.NotFound(uuid=id)
-        server, volumes = load_server(context, db_info.id,
-                                      db_info.compute_instance_id)
+        server, volumes = load_server_with_volumes(context, db_info.id,
+            db_info.compute_instance_id)
         task_status = db_info.task_status
         service_status = InstanceServiceStatus.find_by(instance_id=id)
         LOG.info("service status=%s" % service_status)
@@ -208,6 +208,9 @@ class Instance(object):
                                         volume_size,
                                         display_name="mysql-%s" % db_info.id,
                                         display_description=volume_desc)
+            # Record the volume ID in case something goes wrong.
+            db_info.volume_id = volume_ref.id
+            db_info.save()
             #TODO(cp16net) this is bad to wait here for the volume create
             # before returning but this was a quick way to get it working
             # for now we need this to go into the task manager
@@ -219,8 +222,7 @@ class Instance(object):
                 v_ref = volume_client.volumes.get(volume_ref.id)
 
             if v_ref.status in ['error']:
-                raise rd_exceptions.ReddwarfError(
-                                    _("Could not create volume"))
+                raise rd_exceptions.VolumeCreationFailure()
             LOG.debug(_("Created volume %s") % v_ref)
             # The mapping is in the format:
             # <id>:[<type>]:[<size(GB)>]:[<delete_on_terminate>]
@@ -232,10 +234,10 @@ class Instance(object):
             # guest. Also in cases for ovz where this is mounted on
             # the host, that's not going to work for us.
             block_device = {'vdb': mapping}
-            volume = [{'id': v_ref.id,
+            volumes = [{'id': v_ref.id,
                        'size': v_ref.size}]
             LOG.debug("block_device = %s" % block_device)
-            LOG.debug("volume = %s" % volume)
+            LOG.debug("volume = %s" % volumes)
 
             device_path = CONFIG.get('device_path')
             mount_point = CONFIG.get('mount_point')
@@ -246,12 +248,16 @@ class Instance(object):
             block_device = None
             device_path = None
             mount_point = None
-            volume = None
+            volumes = None
             #end volume_support
+        #block_device = ""
+        #device_path = /dev/vdb
+        #mount_point = /var/lib/mysql
         volume_info = {'block_device': block_device,
                        'device_path': device_path,
-                       'mount_point': mount_point}
-        return volume, volume_info
+                       'mount_point': mount_point,
+                       'volumes': volumes}
+        return volume_info
 
     @classmethod
     def create(cls, context, name, flavor_ref, image_id,
@@ -259,15 +265,25 @@ class Instance(object):
         db_info = DBInstance.create(name=name,
             task_status=InstanceTasks.NONE)
         LOG.debug(_("Created new Reddwarf instance %s...") % db_info.id)
-        volume, volume_info = cls._create_volume(context,
-                                                     db_info,
-                                                     volume_size)
+
+        if volume_size:
+            volume_info = cls._create_volume(context, db_info, volume_size)
+            block_device_mapping = volume_info['block_device']
+            device_path=volume_info['device_path']
+            mount_point=volume_info['mount_point']
+            volumes = volume_info['volumes']
+        else:
+            block_device_mapping = None
+            device_path=None
+            mount_point=None
+            volumes = []
+
         client = create_nova_client(context)
         files = {"/etc/guest_info": "guest_id=%s\nservice_type=%s\n" %
                  (db_info.id, service_type)}
         server = client.servers.create(name, image_id, flavor_ref,
                      files=files,
-                     block_device_mapping=volume_info['block_device'])
+                     block_device_mapping=block_device_mapping)
         LOG.debug(_("Created new compute instance %s.") % server.id)
 
         db_info.compute_instance_id = server.id
@@ -281,9 +297,9 @@ class Instance(object):
         # populate the databases
         model_schemas = populate_databases(databases)
         guest.prepare(512, model_schemas, users=[],
-                      device_path=volume_info['device_path'],
-                      mount_point=volume_info['mount_point'])
-        return Instance(context, db_info, server, service_status, volume)
+                      device_path=device_path,
+                      mount_point=mount_point)
+        return Instance(context, db_info, server, service_status, volumes)
 
     def get_guest(self):
         return create_guest_client(self.context, self.db_info.id)
@@ -377,9 +393,10 @@ class Instance(object):
 
     def _refresh_compute_server_info(self):
         """Refreshes the compute server field."""
-        server = load_server(self.context, self.db_info.id,
-                             self.db_info.compute_instance_id)
+        server, volumes = load_server_with_volumes(self.context,
+            self.db_info.id, self.db_info.compute_instance_id)
         self.server = server
+        self.volumes = volumes
         return server
 
     def resize_flavor(self, new_flavor_id):
@@ -631,7 +648,8 @@ class DBInstance(DatabaseModelBase):
     #TODO(tim.simpson): Add start time.
 
     _data_fields = ['name', 'created', 'compute_instance_id',
-                    'task_id', 'task_description', 'task_start_time']
+                    'task_id', 'task_description', 'task_start_time',
+                    'volume_id']
 
     def __init__(self, task_status=None, **kwargs):
         kwargs["task_id"] = task_status.code

--- a/reddwarf/instance/service.py
+++ b/reddwarf/instance/service.py
@@ -53,6 +53,9 @@ class BaseController(wsgi.Controller):
             ],
         webob.exc.HTTPConflict: [
             ],
+        webob.exc.HTTPRequestEntityTooLarge: [
+            exception.OverLimit,
+            ]
         }
 
     def __init__(self):

--- a/reddwarf/instance/service.py
+++ b/reddwarf/instance/service.py
@@ -46,6 +46,7 @@ class BaseController(wsgi.Controller):
         webob.exc.HTTPBadRequest: [
             models.InvalidModelError,
             exception.BadRequest,
+            exception.CannotResizeToSameSize,
             ],
         webob.exc.HTTPNotFound: [
             exception.NotFound,
@@ -152,7 +153,7 @@ class InstanceController(BaseController):
                 raise rd_exceptions.BadRequest("Invalid resize argument %s"
                                                % key)
         if selected_option:
-            return selected_option(self, instance, args)
+            return selected_option(instance, args)
         else:
             raise rd_exceptions.BadRequest(_("Missing resize arguments."))
 

--- a/reddwarf/instance/service.py
+++ b/reddwarf/instance/service.py
@@ -262,7 +262,10 @@ class InstanceController(BaseController):
         databases = body['instance'].get('databases')
         if databases is None:
             databases = []
-        volume_size = body['instance']['volume']['size']
+        if body['instance'].get('volume', None) is not None:
+            volume_size = body['instance']['volume']['size']
+        else:
+            volume_size = None
         instance = models.Instance.create(context, name, flavor_ref,
                                           image_id, databases,
                                           service_type, volume_size)
@@ -284,8 +287,8 @@ class InstanceController(BaseController):
             volume_size = float(size)
         except (ValueError, TypeError) as err:
             LOG.error(err)
-            msg = ("Required element/key - instance volume"
-                   "'size' was not specified as a number")
+            msg = ("Required element/key - instance volume 'size' was not "
+                   "specified as a number (value was %s)." % size)
             raise rd_exceptions.ReddwarfError(msg)
         if int(volume_size) != volume_size or int(volume_size) < 1:
             msg = ("Volume 'size' needs to be a positive "
@@ -308,12 +311,13 @@ class InstanceController(BaseController):
             body['instance']
             body['instance']['flavorRef']
             # TODO(cp16net) add in volume to the mix
-            volume_size = body['instance']['volume']['size']
+            if 'volume' in body['instance'] and \
+                body['instance']['volume'] is not None:
+                volume_size = body['instance']['volume']['size']
         except KeyError as e:
             LOG.error(_("Create Instance Required field(s) - %s") % e)
             raise rd_exceptions.ReddwarfError("Required element/key - %s "
                                        "was not specified" % e)
-        InstanceController._validate_volume_size(volume_size)
 
     @staticmethod
     def _validate_resize_instance(body):

--- a/reddwarf/instance/tasks.py
+++ b/reddwarf/instance/tasks.py
@@ -58,6 +58,7 @@ class InstanceTasks(object):
     NONE = InstanceTask(0x01, 'NONE')
     DELETING = InstanceTask(0x02, 'DELETING')
     REBOOTING = InstanceTask(0x03, 'REBOOTING')
+    RESIZING = InstanceTask(0x03, 'RESIZING')
 
 
 # Dissuade further additions at run-time.

--- a/reddwarf/instance/tasks.py
+++ b/reddwarf/instance/tasks.py
@@ -58,7 +58,7 @@ class InstanceTasks(object):
     NONE = InstanceTask(0x01, 'NONE')
     DELETING = InstanceTask(0x02, 'DELETING')
     REBOOTING = InstanceTask(0x03, 'REBOOTING')
-    RESIZING = InstanceTask(0x03, 'RESIZING')
+    RESIZING = InstanceTask(0x04, 'RESIZING')
 
 
 # Dissuade further additions at run-time.

--- a/reddwarf/tests/fakes/guestagent.py
+++ b/reddwarf/tests/fakes/guestagent.py
@@ -89,23 +89,16 @@ class FakeGuest(object):
     def start_mysql_with_conf_changes(self, updated_memory_size):
         from reddwarf.instance.models import InstanceServiceStatus
         from reddwarf.instance.models import ServiceStatuses
-
-        def update_db():
-            status = InstanceServiceStatus.find_by(instance_id=self.id)
-            status.status = ServiceStatuses.RUNNING
-            status.save()
-        EventSimulator.add_event(0.5, update_db)
+        status = InstanceServiceStatus.find_by(instance_id=self.id)
+        status.status = ServiceStatuses.RUNNING
+        status.save()
 
     def stop_mysql(self):
         from reddwarf.instance.models import InstanceServiceStatus
         from reddwarf.instance.models import ServiceStatuses
-
-        def update_db():
-            status = InstanceServiceStatus.find_by(instance_id=self.id)
-            status.status = ServiceStatuses.SHUTDOWN
-            status.save()
-        EventSimulator.add_event(0.5, update_db)
-
+        status = InstanceServiceStatus.find_by(instance_id=self.id)
+        status.status = ServiceStatuses.SHUTDOWN
+        status.save()
 
 def get_or_create(id):
     if id not in DB:

--- a/reddwarf/tests/fakes/nova.py
+++ b/reddwarf/tests/fakes/nova.py
@@ -59,6 +59,7 @@ class FakeFlavors(object):
         self._add(3, 10, "m1.medium", 4096)
         self._add(4, 10, "m1.large", 8192)
         self._add(5, 10, "m1.xlarge", 16384)
+        self._add(6, 0, "tinier", 506)
 
     def _add(self, *args, **kwargs):
         new_flavor = FakeFlavor(*args, **kwargs)
@@ -86,7 +87,7 @@ class FakeFlavors(object):
 class FakeServer(object):
 
     def __init__(self, parent, owner, id, name, image_id, flavor_ref,
-                 block_device_mapping):
+                 block_device_mapping, volumes):
         self.owner = owner  # This is a context.
         self.id = id
         self.parent = parent
@@ -95,8 +96,7 @@ class FakeServer(object):
         self.flavor_ref = flavor_ref
         self.events = EventSimulator()
         self.schedule_status("BUILD", 0.0)
-        LOG.debug("block_device_mapping = %s" % block_device_mapping)
-        self.block_device_mapping = block_device_mapping
+        self.volumes = volumes
 
     @property
     def addresses(self):
@@ -176,12 +176,31 @@ class FakeServers(object):
     def create(self, name, image_id, flavor_ref, files, block_device_mapping):
         id = "FAKE_%d" % self.next_id
         self.next_id += 1
+        volumes = self._get_volumes_from_bdm(block_device_mapping)
         server = FakeServer(self, self.context, id, name, image_id, flavor_ref,
-                            block_device_mapping)
+                            block_device_mapping, volumes)
         self.db[id] = server
         server.schedule_status("ACTIVE", 1)
         LOG.info("FAKE_SERVERS_DB : %s" % str(FAKE_SERVERS_DB))
         return server
+
+    def _get_volumes_from_bdm(self, block_device_mapping):
+        volumes = []
+        if block_device_mapping is not None:
+            # block_device_mapping is a dictionary, where the key is the
+            # device name on the compute instance and the mapping info is a
+            # set of fields in a string, seperated by colons.
+            # For each device, find the volume, and record the mapping info
+            # to another fake object and attach it to the volume
+            # so that the fake API can later retrieve this.
+            for device in block_device_mapping:
+                mapping = block_device_mapping[device]
+                (id, _type, size, delete_on_terminate) = mapping.split(":")
+                volume = self.volumes.get(id)
+                volume.mapping = FakeBlockDeviceMappingInfo(id, device,
+                    _type, size, delete_on_terminate)
+                volumes.append(volume)
+        return volumes
 
     def get(self, id):
         if id not in self.db:
@@ -193,6 +212,11 @@ class FakeServers(object):
                 return self.db[id]
             else:
                 raise nova_exceptions.NotFound(404, "Bad permissions")
+
+    def get_server_volumes(self, server_id):
+        return [volume.mapping
+                for volume in self.get(server_id).volumes
+                if volume.mapping is not None]
 
     def list(self):
         return [v for (k, v) in self.db.items() if self.can_see(v.id)]
@@ -223,20 +247,8 @@ class FakeServerVolumes(object):
         return [ServerVolumes(server.block_device_mapping)]
 
 
-FLAVORS = FakeFlavors()
 
 
-class FakeClient(object):
-
-    def __init__(self, context):
-        self.context = context
-        self.flavors = FLAVORS
-        self.servers = FakeServers(context, self.flavors)
-        self.volumes = FakeServerVolumes(context)
-
-
-def fake_create_nova_client(context):
-    return FakeClient(context)
 
 
 class FakeVolume(object):
@@ -266,6 +278,16 @@ class FakeVolume(object):
     @property
     def status(self):
         return self._current_status
+
+
+class FakeBlockDeviceMappingInfo(object):
+
+    def __init__(self, id, device, _type, size, delete_on_terminate):
+        self.volumeId = id
+        self.device = device
+        self.type = _type
+        self.size = size
+        self.delete_on_terminate = delete_on_terminate
 
 
 FAKE_VOLUMES_DB = {}
@@ -307,12 +329,40 @@ class FakeVolumes(object):
         return volume
 
 
-class FakeVolumeClient(object):
+FLAVORS = FakeFlavors()
+
+class FakeClient(object):
 
     def __init__(self, context):
         self.context = context
+        self.flavors = FLAVORS
+        self.servers = FakeServers(context, self.flavors)
         self.volumes = FakeVolumes(context)
+        self.servers.volumes = self.volumes
+
+    def get_server_volumes(self, server_id):
+        return self.servers.get_server_volumes(server_id)
+
+
+CLIENT_DATA = {}
+
+
+def get_client_data(context):
+    if context not in CLIENT_DATA:
+        nova_client = FakeClient(context)
+        volume_client = FakeClient(context)
+        nova_client.volumes = volume_client
+        volume_client.servers = nova_client
+        CLIENT_DATA[context] = {
+            'nova': nova_client,
+            'volume': volume_client
+        }
+    return CLIENT_DATA[context]
+
+
+def fake_create_nova_client(context):
+    return get_client_data(context)['nova']
 
 
 def fake_create_nova_volume_client(context):
-    return FakeVolumeClient(context)
+    return get_client_data(context)['volume']


### PR DESCRIPTION
- Added FlavorNotFound and OverLimit exceptions.
- Added restart_with_sync.
- Added resize_flavor method to instance/models.py.
- Raise CannotResizeToSameSize when trying to do so.
- Changed create_user to use grant statements.
- Fixed bug where starting mysql would fail if the ib_logs had mysteriously vanished.
- Added async call stub, which will work ok until we get the task manager in place.
- Changed resize flavor to do much of its work asynchronously, since we have to wait until we can confirm a resize in Nova.
- Added a RESIZING task.
