### PR TITLE
Fix XML serialization for instance not found.

### DIFF
--- a/etc/reddwarf/reddwarf.conf.test
+++ b/etc/reddwarf/reddwarf.conf.test
@@ -75,7 +75,7 @@ notifier_queue_transport = memory
 [composite:reddwarf]
 use = call:reddwarf.common.wsgi:versioned_urlmap
 /: versions
-/v0.1: reddwarfapi
+/v1.0: reddwarfapi
 
 [app:versions]
 paste.app_factory = reddwarf.versions:app_factory

--- a/reddwarf/instance/service.py
+++ b/reddwarf/instance/service.py
@@ -51,6 +51,7 @@ class BaseController(wsgi.Controller):
             ],
         webob.exc.HTTPNotFound: [
             exception.NotFound,
+            exception.ComputeInstanceNotFound,
             models.ModelNotFoundError,
             ],
         webob.exc.HTTPConflict: [
@@ -209,14 +210,7 @@ class InstanceController(BaseController):
         LOG.info(_("id : '%s'\n\n") % id)
 
         context = req.environ[wsgi.CONTEXT_KEY]
-        try:
-            # TODO(hub-cap): start testing the failure cases here
-            server = models.Instance.load(context=context, id=id)
-        except exception.ReddwarfError, e:
-            # TODO(hub-cap): come up with a better way than
-            #    this to get the message
-            LOG.error(e)
-            return wsgi.Result(str(e), 404)
+        server = models.Instance.load(context=context, id=id)
         # TODO(cp16net): need to set the return code correctly
         return wsgi.Result(views.InstanceDetailView(server, req=req,
                            add_addresses=self.add_addresses,
@@ -229,17 +223,8 @@ class InstanceController(BaseController):
         LOG.info(_("id : '%s'\n\n") % id)
         # TODO(hub-cap): turn this into middleware
         context = req.environ[wsgi.CONTEXT_KEY]
-        try:
-            # TODO(hub-cap): start testing the failure cases here
-            instance = models.Instance.load(context=context, id=id)
-        except exception.ReddwarfError, e:
-            # TODO(hub-cap): come up with a better way than
-            #    this to get the message
-            LOG.error(e)
-            return wsgi.Result(str(e), 404)
-
+        instance = models.Instance.load(context=context, id=id)
         instance.delete()
-
         # TODO(cp16net): need to set the return code correctly
         return wsgi.Result(None, 202)
 

--- a/reddwarf/tests/fakes/nova.py
+++ b/reddwarf/tests/fakes/nova.py
@@ -61,6 +61,7 @@ class FakeFlavors(object):
         self._add(5, 10, "m1.xlarge", 16384)
         self._add(6, 0, "tinier", 506)
         self._add(7, 0, "m1.rd-tiny", 512)
+        self._add(8, 0, "m1.rd-smaller", 768)
 
     def _add(self, *args, **kwargs):
         new_flavor = FakeFlavor(*args, **kwargs)


### PR DESCRIPTION
When you get an instance that isn't found, it breaks in XML mode. This fixes that.
