### PR TITLE
volume list should return a list of dict and not objects

### DIFF
--- a/reddwarf/instance/models.py
+++ b/reddwarf/instance/models.py
@@ -594,8 +594,10 @@ def create_server_list_matcher(server_list):
 def create_volumes_list_matcher(volume_list):
     # Returns a method which finds a volume from the given list.
     def find_volumes(server_id):
-        return [volume for volume in volume_list if server_id in
-                [attachment["server_id"] for attachment in volume.attachments]]
+        return [{'id': volume.id, 'size': volume.size}
+                    for volume in volume_list
+                        if server_id in [attachment["server_id"]
+                            for attachment in volume.attachments]]
     return find_volumes
 
 


### PR DESCRIPTION
Caused problems converting the volumes to a view in the `get_volumes(volumes)` because it has expected each volume to be a dictionary and instead now on get instance it was an object. 

This fix converts that object into the expected dictionary exactly like the create instance does as well.
