### PR TITLE
No longer call to Nova to grab server or volume info for majority of instance calls.

### DIFF
--- a/reddwarf/db/sqlalchemy/migrate_repo/versions/007_add_instance_fields.py
+++ b/reddwarf/db/sqlalchemy/migrate_repo/versions/007_add_instance_fields.py
@@ -13,8 +13,10 @@
 #    under the License.
 
 from sqlalchemy.schema import Column
+from sqlalchemy.schema import ColumnDefault
 from sqlalchemy.schema import MetaData
 
+from reddwarf.db.sqlalchemy.migrate_repo.schema import Integer
 from reddwarf.db.sqlalchemy.migrate_repo.schema import String
 from reddwarf.db.sqlalchemy.migrate_repo.schema import Table
 
@@ -25,11 +27,10 @@ def upgrade(migrate_engine):
 
     # add column:
     instances = Table('instances', meta, autoload=True)
-    volume_size = Column('volume_size', String(36))
-    flavor_id = Column('flavor_id', String(36))
-
-    instances.create_column(flavor_id)
-    instances.create_column(volume_size)
+    instances.create_column(Column('flavor_id', String(36), nullable=True))
+    instances.create_column(Column('volume_size', Integer(), nullable=True))
+    instances.create_column(Column('tenant_id', String(36), nullable=True))
+    instances.create_column(Column('server_status', String(64)))
 
 
 def downgrade(migrate_engine):
@@ -41,3 +42,5 @@ def downgrade(migrate_engine):
 
     instances.drop_column('flavor_id')
     instances.drop_column('volume_size')
+    instances.drop_column('tenant_id')
+    instances.drop_column('server_status')

--- a/reddwarf/instance/tasks.py
+++ b/reddwarf/instance/tasks.py
@@ -59,6 +59,7 @@ class InstanceTasks(object):
     DELETING = InstanceTask(0x02, 'DELETING')
     REBOOTING = InstanceTask(0x03, 'REBOOTING')
     RESIZING = InstanceTask(0x04, 'RESIZING')
+    BUILDING = InstanceTask(0x05, 'BUILDING')
 
 
 # Dissuade further additions at run-time.

--- a/reddwarf/taskmanager/api.py
+++ b/reddwarf/taskmanager/api.py
@@ -20,6 +20,8 @@ Routes all the requests to the task manager.
 
 
 import logging
+import traceback
+import sys
 
 from reddwarf import rpc
 from reddwarf.common import config
@@ -27,6 +29,7 @@ from reddwarf.common import exception
 from reddwarf.common import utils
 
 
+CONFIG = config.Config
 LOG = logging.getLogger(__name__)
 
 
@@ -36,15 +39,32 @@ class API(object):
     def __init__(self, context):
         self.context = context
 
-    def _call(self, method_name, **kwargs):
-        try:
-            return rpc.call(self.context, self._get_routing_key(),
-                            {"method": method_name, "args": kwargs})
-        except Exception as e:
-            LOG.error(e)
-            raise exception.TaskManagerError(original_message=str(e))
-
     def _cast(self, method_name, **kwargs):
+        if CONFIG.get("remote_implementation", "real") == "fake":
+            self._fake_cast(method_name, **kwargs)
+        else:
+            self._real_cast(method_name, **kwargs)
+
+    def _fake_cast(self, method_name, **kwargs):
+        import eventlet
+        from reddwarf.taskmanager.manager import TaskManager
+        instance = TaskManager()
+        method = getattr(instance, method_name)
+        def func():
+            try:
+                method(self.context, **kwargs)
+            except Exception as ex:
+                type_, value, tb = sys.exc_info()
+                logging.error("Error running async task:")
+                logging.error((traceback.format_exception(type_, value, tb)))
+                raise type_, value, tb
+        eventlet.spawn_after(0, func)
+
+    def _get_routing_key(self):
+        """Create the routing key for the taskmanager"""
+        return "taskmanager"
+
+    def _real_cast(self, method_name, **kwargs):
         try:
             rpc.cast(self.context, self._get_routing_key(),
                     {"method": method_name, "args": kwargs})
@@ -52,23 +72,19 @@ class API(object):
             LOG.error(e)
             raise exception.TaskManagerError(original_message=str(e))
 
-    def _get_routing_key(self):
-        """Create the routing key for the taskmanager"""
-        return "taskmanager"
-
     def resize_volume(self, new_size, instance_id):
         LOG.debug("Making async call to resize volume for instance: %s"
                  % instance_id)
         self._cast("resize_volume", new_size=new_size, instance_id=instance_id)
 
-    def resize_flavor(self, instance_id, new_flavor_id, old_flavor_size,
-                      new_flavor_size):
+    def resize_flavor(self, instance_id, new_flavor_id, old_memory_size,
+                      new_memory_size):
         LOG.debug("Making async call to resize flavor for instance: %s" %
                   instance_id)
         self._cast("resize_flavor", instance_id=instance_id,
                    new_flavor_id=new_flavor_id,
-                   old_flavor_size=old_flavor_size,
-                   new_flavor_size=new_flavor_size)
+                   old_memory_size=old_memory_size,
+                   new_memory_size=new_memory_size)
 
     def restart(self, instance_id):
         LOG.debug("Making async call to restart instance: %s" % instance_id)
@@ -78,10 +94,10 @@ class API(object):
         LOG.debug("Making async call to delete instance: %s" % instance_id)
         self._cast("delete_instance", instance_id=instance_id)
 
-    def create_instance(self, instance_id, name, flavor_ref, image_id,
-                        databases, service_type, volume_size):
+    def create_instance(self, instance_id, name, flavor_id, flavor_ram,
+                        image_id, databases, service_type, volume_size):
         LOG.debug("Making async call to create instance %s " % instance_id)
         self._cast("create_instance", instance_id=instance_id, name=name,
-                   flavor_ref=flavor_ref, image_id=image_id,
-                   databases=databases, service_type=service_type,
-                   volume_size=volume_size)
+                   flavor_id=flavor_id, flavor_ram=flavor_ram,
+                   image_id=image_id, databases=databases,
+                   service_type=service_type, volume_size=volume_size)

--- a/reddwarf/taskmanager/manager.py
+++ b/reddwarf/taskmanager/manager.py
@@ -23,7 +23,8 @@ from eventlet import greenthread
 
 from reddwarf.common import service
 from reddwarf.taskmanager import models
-from reddwarf.taskmanager.models import InstanceTasks
+from reddwarf.taskmanager.models import BuiltInstanceTasks
+from reddwarf.taskmanager.models import FreshInstanceTasks
 
 
 LOG = logging.getLogger(__name__)
@@ -55,28 +56,28 @@ class TaskManager(service.Manager):
             del self.tasks[greenthread.getcurrent()]
 
     def resize_volume(self, context, instance_id, new_size):
-        instance_tasks = models.InstanceTasks.load(context, instance_id)
+        instance_tasks = models.BuiltInstanceTasks.load(context, instance_id)
         instance_tasks.resize_volume(new_size)
 
     def resize_flavor(self, context, instance_id, new_flavor_id,
-                      old_flavor_size, new_flavor_size):
-        instance_tasks = models.InstanceTasks.load(context, instance_id)
-        instance_tasks.resize_flavor(new_flavor_id, old_flavor_size,
-                                     new_flavor_size)
+                      old_memory_size, new_memory_size):
+        instance_tasks = models.BuiltInstanceTasks.load(context, instance_id)
+        instance_tasks.resize_flavor(new_flavor_id, old_memory_size,
+                                     new_memory_size)
 
     def restart(self, context, instance_id):
-        instance_tasks = models.InstanceTasks.load(context, instance_id)
+        instance_tasks = models.BuiltInstanceTasks.load(context, instance_id)
         instance_tasks.restart()
 
     def delete_instance(self, context, instance_id):
-        instance_tasks = models.InstanceTasks.load(context, instance_id)
+        instance_tasks = models.BuiltInstanceTasks.load(context, instance_id)
         instance_tasks.delete_instance()
 
-    def create_instance(self, context, instance_id, name, flavor_ref,
-                        image_id, databases, service_type, volume_size):
-        instance_tasks = InstanceTasks(context)
-        instance_tasks.create_instance(instance_id, name, flavor_ref,
-                                       image_id, databases,
-                                       service_type, volume_size)
+    def create_instance(self, context, instance_id, name, flavor_id,
+                        flavor_ram, image_id, databases, service_type,
+                        volume_size):
+        instance_tasks = FreshInstanceTasks.load(context, instance_id)
+        instance_tasks.create_instance(flavor_id, flavor_ram, image_id,
+                                       databases, service_type, volume_size)
 
 

--- a/reddwarf/taskmanager/models.py
+++ b/reddwarf/taskmanager/models.py
@@ -32,6 +32,8 @@ from reddwarf.common.remote import create_guest_client
 from reddwarf.common.utils import poll_until
 from reddwarf.instance import models as inst_models
 from reddwarf.instance.models import DBInstance
+from reddwarf.instance.models import BuiltInstance
+from reddwarf.instance.models import FreshInstance
 from reddwarf.instance.models import InstanceStatus
 from reddwarf.instance.models import InstanceServiceStatus
 from reddwarf.instance.models import populate_databases
@@ -42,52 +44,144 @@ from reddwarf.instance.views import get_ip_address
 LOG = logging.getLogger(__name__)
 
 
-class InstanceTasks:
+class FreshInstanceTasks(FreshInstance):
+
+    def create_instance(self, flavor_id, flavor_ram,
+                        image_id, databases, service_type, volume_size):
+        try:
+            volume_info = self._create_volume(volume_size)
+            block_device_mapping = volume_info['block_device']
+            server = self._create_server(flavor_id, image_id, service_type,
+                                         block_device_mapping)
+            server_id = server.id
+            # Save server ID.
+            self.update_db(compute_instance_id=server_id)
+            self._create_dns_entry()
+            self._guest_prepare(server, flavor_ram, volume_info, databases)
+        finally:
+            self.update_db(task_status=inst_models.InstanceTasks.NONE)
+
+    def _create_volume(self, volume_size):
+        LOG.info("Entering create_volume")
+        LOG.debug(_("Starting to create the volume for the instance"))
+
+        volume_support = config.Config.get("reddwarf_volume_support", 'False')
+        LOG.debug(_("reddwarf volume support = %s") % volume_support)
+        if volume_size is None or \
+           utils.bool_from_string(volume_support) is False:
+            volume_info = {'block_device': None,
+                           'device_path': None,
+                           'mount_point': None,
+                           'volumes': None}
+            return volume_info
+
+        volume_client = create_nova_volume_client(self.context)
+        volume_desc = ("mysql volume for %s" % self.id)
+        volume_ref = volume_client.volumes.create(
+                        volume_size,
+                        display_name="mysql-%s" % self.id,
+                        display_description=volume_desc)
+
+        # Record the volume ID in case something goes wrong.
+        self.update_db(volume_id=volume_ref.id)
+
+        utils.poll_until(
+            lambda: volume_client.volumes.get(volume_ref.id),
+            lambda v_ref: v_ref.status in ['available', 'error'],
+            sleep_time=2,
+            time_out=2 * 60)
+
+        v_ref = volume_client.volumes.get(volume_ref.id)
+        if v_ref.status in ['error']:
+            raise VolumeCreationFailure()
+        LOG.debug(_("Created volume %s") % v_ref)
+        # The mapping is in the format:
+        # <id>:[<type>]:[<size(GB)>]:[<delete_on_terminate>]
+        # setting the delete_on_terminate instance to true=1
+        mapping = "%s:%s:%s:%s" % (v_ref.id, '', v_ref.size, 1)
+        bdm = config.Config.get('block_device_mapping', 'vdb')
+        block_device = {bdm: mapping}
+        volumes = [{'id': v_ref.id,
+                    'size': v_ref.size}]
+        LOG.debug("block_device = %s" % block_device)
+        LOG.debug("volume = %s" % volumes)
+
+
+        device_path = config.Config.get('device_path', '/dev/vdb')
+        mount_point = config.Config.get('mount_point', '/var/lib/mysql')
+        LOG.debug(_("device_path = %s") % device_path)
+        LOG.debug(_("mount_point = %s") % mount_point)
+
+        volume_info = {'block_device': block_device,
+                       'device_path': device_path,
+                       'mount_point': mount_point,
+                       'volumes': volumes}
+        return volume_info
+
+    def _create_server(self, flavor_id, image_id,
+                       service_type, block_device_mapping):
+        nova_client = create_nova_client(self.context)
+        files = {"/etc/guest_info": "guest_id=%s\nservice_type=%s\n" %
+                                    (self.id, service_type)}
+        server = nova_client.servers.create(self.name, image_id, flavor_id,
+                        files=files, block_device_mapping=block_device_mapping)
+        LOG.debug(_("Created new compute instance %s.") % server.id)
+        return server
+
+    def _guest_prepare(self, server, flavor_ram, volume_info, databases):
+        LOG.info("Entering guest_prepare.")
+        # Now wait for the response from the create to do additional work
+        # populate the databases
+        model_schemas = populate_databases(databases)
+        self.guest.prepare(flavor_ram, model_schemas, users=[],
+                      device_path=volume_info['device_path'],
+                      mount_point=volume_info['mount_point'])
+
+    def _create_dns_entry(self):
+        LOG.debug("%s: Creating dns entry for instance: %s"
+                  % (greenthread.getcurrent(), self.id))
+        dns_client = create_dns_client(self.context)
+        dns_support = config.Config.get("reddwarf_dns_support", 'False')
+        LOG.debug(_("reddwarf dns support = %s") % dns_support)
+
+        nova_client = create_nova_client(self.context)
+        if utils.bool_from_string(dns_support):
+            def get_server():
+                return nova_client.servers.get(self.db_info.compute_instance_id)
+
+            def ip_is_available(server):
+                LOG.info("Polling for ip addresses: $%s " % server.addresses)
+                if server.addresses != {}:
+                    return True
+                elif server.addresses == {} and\
+                     server.status != InstanceStatus.ERROR:
+                    return False
+                elif server.addresses == {} and\
+                     server.status == InstanceStatus.ERROR:
+                    LOG.error(_("Instance IP not available, instance (%s): "
+                                "server had status (%s).")
+                    % (self.id, server.status))
+                    raise ReddwarfError(status=server.status)
+            poll_until(get_server, ip_is_available,
+                       sleep_time=1, time_out=60 * 2)
+            server = nova_client.servers.get(self.db_info.compute_instance_id)
+            LOG.info("Creating dns entry...")
+            dns_client.create_instance_entry(self.id,
+                                             get_ip_address(server.addresses))
+
+
+class BuiltInstanceTasks(BuiltInstance):
     """
     Performs the various asynchronous instance related tasks.
     """
 
-    def __init__(self, context, db_info=None, server=None, volumes=None,
-                 nova_client=None, volume_client=None, guest=None):
-        self.context = context
-        self.db_info = db_info
-        self.server = server
-        self.volumes = volumes
-        self.nova_client = nova_client
-        self.volume_client = volume_client
-        self.guest = guest
-
-    @property
-    def volume_id(self):
-        return self.volumes[0]['id']
-
-    @property
-    def volume_mountpoint(self):
-        mountpoint = self.volumes[0]['mountpoint']
+    def get_volume_mountpoint(self):
+        volume = create_nova_volume_client(self.context).volumes.get(volume_id)
+        mountpoint = volume.attachments[0]['device']
         if mountpoint[0] is not "/":
             return "/%s" % mountpoint
         else:
             return mountpoint
-
-    @staticmethod
-    def load(context, id):
-        if context is None:
-            raise TypeError("Argument context not defined.")
-        elif id is None:
-            raise TypeError("Argument id not defined.")
-        try:
-            db_info = inst_models.DBInstance.find_by(id=id)
-        except NotFound:
-            raise NotFound(uuid=id)
-        server, volumes = inst_models.load_server_with_volumes(context,
-                                                db_info.id,
-                                                db_info.compute_instance_id)
-        nova_client = remote.create_nova_client(context)
-        volume_client = remote.create_nova_volume_client(context)
-        guest = remote.create_guest_client(context, id)
-        return InstanceTasks(context, db_info, server, volumes,
-                             nova_client=nova_client,
-                             volume_client=volume_client, guest=guest)
 
     def delete_instance(self):
         try:
@@ -118,9 +212,11 @@ class InstanceTasks:
                         lambda volume: volume.status == 'in-use',
                         sleep_time=2,
                         time_out=int(config.Config.get('volume_time_out')))
+            volume = self.volume_client.volumes.get(self.volume_id)
+            self.update_db(volume_size=volume.size)
             self.nova_client.volumes.rescan_server_volume(self.server,
                                                           self.volume_id)
-            self.guest.resize_fs(self.volume_mountpoint)
+            self.guest.resize_fs(self.get_volume_mountpoint())
         except PollTimeOut as pto:
             LOG.error("Timeout trying to rescan or resize the attached volume "
                       "filesystem for volume: %s" % self.volume_id)
@@ -129,8 +225,7 @@ class InstanceTasks:
                       "attached volume filesystem for volume: %s"
                       % self.volume_id)
         finally:
-            self.db_info.task_status = inst_models.InstanceTasks.NONE
-            self.db_info.save()
+            self.update_db(task_status=inst_models.InstanceTasks.NONE)
 
     def resize_flavor(self, new_flavor_id, old_memory_size,
                       new_memory_size):
@@ -174,6 +269,10 @@ class InstanceTasks:
                 LOG.debug("Instance %s calling Compute confirm resize..."
                           % self.db_info.id)
                 self.server.confirm_resize()
+                # Record the new flavor_id in our database.
+                LOG.debug("Updating instance %s to flavor_id %s."
+                          % (self.id, new_flavor_id))
+                self.update_db(flavor_id=new_flavor_id)
             except PollTimeOut as pto:
                 LOG.error("Timeout trying to resize the flavor for instance "
                           " %s" % self.db_info.id)
@@ -189,164 +288,18 @@ class InstanceTasks:
                 LOG.debug("Instance %s starting mysql..." % self.db_info.id)
                 self.guest.start_mysql_with_conf_changes(new_memory_size)
         finally:
-            self.db_info.task_status = inst_models.InstanceTasks.NONE
-            self.db_info.save()
-
-    def create_instance(self, instance_id, name, flavor_ref,
-                            image_id, databases, service_type, volume_size):
-        LOG.info("Entering create_instance")
-        try:
-            db_info = DBInstance.find_by(id=instance_id)
-            volume_info = self._create_volume(instance_id,
-                                              volume_size)
-            block_device_mapping = volume_info['block_device']
-            server = self._create_server(instance_id, name,
-                    flavor_ref, image_id, service_type, block_device_mapping)
-            LOG.info("server id: %s" % server)
-            server_id = server.id
-            self._create_dns_entry(instance_id, server_id)
-            LOG.info("volume_info %s " % volume_info)
-            self._guest_prepare(server, db_info, volume_info, databases)
-        except Exception, e:
-            LOG.error(e)
-            self._log_service_status(instance_id, ServiceStatuses.UNKNOWN)
+            self.update_db(task_status=inst_models.InstanceTasks.NONE)
 
     def restart(self):
-        LOG.debug("Restarting instance %s " % self.db_info.id)
+        LOG.debug("Restarting instance %s " % self.id)
         try:
             self.guest.restart()
+            LOG.debug("Restarting successful  %s " % self.id)
         except GuestError:
-            LOG.error("Failure to restart instance %s " % self.db_info.id)
+            LOG.error("Failure to restart MySQL for instance %s." % self.id)
         finally:
-            self.db_info.task_status = inst_models.InstanceTasks.NONE
-            self.db_info.save()
-
-    def _create_volume(self, instance_id, volume_size):
-        LOG.info("Entering create_volume")
-        LOG.debug(_("Starting to create the volume for the instance"))
-
-        volume_support = config.Config.get("reddwarf_volume_support", 'False')
-        LOG.debug(_("reddwarf volume support = %s") % volume_support)
-        if volume_size is None or \
-           utils.bool_from_string(volume_support) is False:
-            volume_info = {'block_device': None,
-                           'device_path': None,
-                           'mount_point': None,
-                           'volumes': None}
-            return volume_info
-
-        db_info = DBInstance.find_by(id=instance_id)
-
-        volume_client = create_nova_volume_client(self.context)
-        volume_desc = ("mysql volume for %s" % instance_id)
-        volume_ref = volume_client.volumes.create(
-                        volume_size,
-                        display_name="mysql-%s" % db_info.id,
-                        display_description=volume_desc)
-
-        # Record the volume ID in case something goes wrong.
-        db_info.volume_id = volume_ref.id
-        db_info.save()
-
-        utils.poll_until(
-            lambda: volume_client.volumes.get(volume_ref.id),
-            lambda v_ref: v_ref.status in ['available', 'error'],
-            sleep_time=2,
-            time_out=2 * 60)
-
-        v_ref = volume_client.volumes.get(volume_ref.id)
-        if v_ref.status in ['error']:
-            raise VolumeCreationFailure()
-        LOG.debug(_("Created volume %s") % v_ref)
-        # The mapping is in the format:
-        # <id>:[<type>]:[<size(GB)>]:[<delete_on_terminate>]
-        # setting the delete_on_terminate instance to true=1
-        mapping = "%s:%s:%s:%s" % (v_ref.id, '', v_ref.size, 1)
-        bdm = config.Config.get('block_device_mapping', 'vdb')
-        block_device = {bdm: mapping}
-        volumes = [{'id': v_ref.id,
-                    'size': v_ref.size}]
-        LOG.debug("block_device = %s" % block_device)
-        LOG.debug("volume = %s" % volumes)
-
-        device_path = config.Config.get('device_path', '/dev/vdb')
-        mount_point = config.Config.get('mount_point', '/var/lib/mysql')
-        LOG.debug(_("device_path = %s") % device_path)
-        LOG.debug(_("mount_point = %s") % mount_point)
-
-        volume_info = {'block_device': block_device,
-                       'device_path': device_path,
-                       'mount_point': mount_point,
-                       'volumes': volumes}
-        return volume_info
-
-    def _create_server(self, instance_id, name, flavor_ref, image_id,
-                       service_type, block_device_mapping):
-        nova_client = create_nova_client(self.context)
-        files = {"/etc/guest_info": "guest_id=%s\nservice_type=%s\n" %
-                                    (instance_id, service_type)}
-        server = nova_client.servers.create(name, image_id, flavor_ref,
-                        files=files, block_device_mapping=block_device_mapping)
-        LOG.debug(_("Created new compute instance %s.") % server.id)
-        return server
-
-    def _guest_prepare(self, server, db_info, volume_info, databases):
-        LOG.info("Entering guest_prepare")
-        db_info.compute_instance_id = server.id
-        db_info.save()
-        self._log_service_status(db_info, ServiceStatuses.NEW)
-
-        # Now wait for the response from the create to do additional work
-        guest = create_guest_client(self.context, db_info.id)
-
-        # populate the databases
-        model_schemas = populate_databases(databases)
-        guest.prepare(512, model_schemas, users=[],
-                      device_path=volume_info['device_path'],
-                      mount_point=volume_info['mount_point'])
-
-    def _create_dns_entry(self, instance_id, server_id):
-        LOG.debug("%s: Creating dns entry for instance: %s"
-                  % (greenthread.getcurrent(), instance_id))
-        dns_client = create_dns_client(self.context)
-        dns_support = config.Config.get("reddwarf_dns_support", 'False')
-        LOG.debug(_("reddwarf dns support = %s") % dns_support)
-
-        nova_client = create_nova_client(self.context)
-        if utils.bool_from_string(dns_support):
-            def get_server():
-                return nova_client.servers.get(server_id)
-
-            def ip_is_available(server):
-                LOG.info("Polling for ip addresses: $%s " % server.addresses)
-                if server.addresses != {}:
-                    return True
-                elif server.addresses == {} and\
-                     server.status != InstanceStatus.ERROR:
-                    return False
-                elif server.addresses == {} and\
-                     server.status == InstanceStatus.ERROR:
-                    LOG.error(_("Instance IP not available, instance (%s): "
-                                "server had status (%s).")
-                    % (instance_id, server.status))
-                    raise ReddwarfError(status=server.status)
-            poll_until(get_server, ip_is_available,
-                       sleep_time=1, time_out=60 * 2)
-            server = nova_client.servers.get(server_id)
-            LOG.info("Creating dns entry...")
-            dns_client.create_instance_entry(instance_id,
-                                             get_ip_address(server.addresses))
-
-    def _log_service_status(self, instance_id, status):
-        LOG.info("Saving service status %s for instance %s "
-                  % (status, instance_id))
-        service_status = InstanceServiceStatus.get_by(instance_id=instance_id)
-        if service_status:
-            service_status.status = status
-            service_status.save()
-        else:
-            InstanceServiceStatus.create(instance_id=instance_id,
-                                         status=status)
+            LOG.debug("Restarting FINALLY  %s " % self.id)
+            self.update_db(task_status=inst_models.InstanceTasks.NONE)
 
     def _refresh_compute_server_info(self):
         """Refreshes the compute server field."""

--- a/reddwarf/tests/fakes/nova.py
+++ b/reddwarf/tests/fakes/nova.py
@@ -267,6 +267,9 @@ class FakeVolume(object):
         self.display_description = display_description
         self.events = EventSimulator()
         self.schedule_status("BUILD", 0.0)
+        # For some reason we grab this thing from device then call it mount
+        # point.
+        self.device = "/var/lib/mysql"
 
     def __repr__(self):
         return ("FakeVolume(id=%s, size=%s, "
@@ -344,6 +347,13 @@ class FakeVolumes(object):
 
     def list(self, detailed=True):
         return [self.db[key] for key in self.db]
+
+    def resize(self, volume_id, new_size):
+        volume = self.get(volume_id)
+        def finish_resize():
+            volume._current_status = "in-use"
+            volume.size = new_size
+        self.events.add_event(1.0, finish_resize)
 
 
 FLAVORS = FakeFlavors()


### PR DESCRIPTION
- Added multiple fields to instances table.
- Deleted 007_add_volume_flavor migration file since we can still redo the DBs.
- Generate links in the instance view code now instead of reusing them from other sources.
- Created SimpleInstance class which avoids loading from Nova API.
- Simplified view objects by taking unnecessary fields out.
- Created a new BUILDING task used for instance create.
- Fixed fake mode for actions performed by the task manager.
- Made the task manager version of Instance extend a common bases with Instance.
- Made two base classes for Instance, one which does not need the Nova server, and one which raises an exception if its not ready.
- Simplified bits of the task manager stuff, which seemed to be passing around the instance_id even though that class effectively is the same as an instance.
