### PR TITLE
Query class now makes use of GROUP BY. This fixes a bug with list_users.

### DIFF
--- a/reddwarf/guestagent/query.py
+++ b/reddwarf/guestagent/query.py
@@ -24,21 +24,23 @@ Intermediary class for building SQL queries for use by the guest agent.
 
 class Query(object):
 
-    def __init__(self, columns=[], tables=[], where=[], order=[], group=[], limit=0):
-        self.columns = columns
-        self.tables = tables
-        self.where = where
-        self.order = order
-        self.group = group
+    def __init__(self, columns=None, tables=None, where=None, order=None, group=None, limit=None):
+        self.columns = columns or []
+        self.tables = tables or []
+        self.where = where or []
+        self.order = order or []
+        self.group = group or []
         self.limit = limit
 
     @property
     def _columns(self):
-        return ', '.join(self.columns) if self.columns else "*"
+        if not self.columns:
+            return "SELECT *"
+        return "SELECT %s" % (', '.join(self.columns))
 
     @property
     def _tables(self):
-        return ', '.join(self.tables)
+        return "FROM %s" % (', '.join(self.tables))
 
     @property
     def _where(self):
@@ -66,8 +68,8 @@ class Query(object):
 
     def __str__(self):
         query = [
-            "SELECT %s" % self._columns,
-            "FROM %s" % self._tables,
+            self._columns,
+            self._tables,
             self._where,
             self._order,
             self._group_by,

--- a/reddwarf/guestagent/query.py
+++ b/reddwarf/guestagent/query.py
@@ -24,11 +24,12 @@ Intermediary class for building SQL queries for use by the guest agent.
 
 class Query(object):
 
-    def __init__(self, columns=[], tables=[], where=[], order=[], limit=0):
+    def __init__(self, columns=[], tables=[], where=[], order=[], group=[], limit=0):
         self.columns = columns
         self.tables = tables
         self.where = where
         self.order = order
+        self.group = group
         self.limit = limit
 
     @property
@@ -52,6 +53,12 @@ class Query(object):
         return "ORDER BY %s" % (', '.join(self.order))
 
     @property
+    def _group_by(self):
+        if not self.group:
+            return ''
+        return "GROUP BY %s" % (', '.join(self.group))
+
+    @property
     def _limit(self):
         if not self.limit:
             return ''
@@ -63,7 +70,8 @@ class Query(object):
             "FROM %s" % self._tables,
             self._where,
             self._order,
-            self._limit
+            self._group_by,
+            self._limit,
             ]
         return '\n'.join(query)
 


### PR DESCRIPTION
Figured out why list_users was coming back with ten times the users it needed--it wasn't deduping the results from the privileges query to map users to dbs. The Query object was already correct, but it just wasn't using group before today. This bug only affects the reference guest agent.
