### PR TITLE
Adding a admin context check used for the management calls

### DIFF
--- a/etc/reddwarf/reddwarf.conf.sample
+++ b/etc/reddwarf/reddwarf.conf.sample
@@ -55,6 +55,9 @@ volume_time_out=30
 # Reddwarf DNS
 reddwarf_dns_support = False
 
+# Auth
+admin_roles = [admin]
+
 # ============ notifer queue kombu connection options ========================
 
 notifier_queue_hostname = localhost

--- a/reddwarf/common/exception.py
+++ b/reddwarf/common/exception.py
@@ -144,3 +144,6 @@ class BadValue(ReddwarfError):
 class PollTimeOut(ReddwarfError):
     message = _("Polling request timed out.")
 
+
+class Forbidden(ReddwarfError):
+    message = _("User does not have admin privileges.")


### PR DESCRIPTION
This is a stop gap solution for us the verify a user with admin privileges. It would be nice to reuse the nova policy stuff or have something more concrete. The nova policy stuff is in openstack-common, we just don't have it updated yet.
