### PR TITLE
Exception name changes

### DIFF
--- a/reddwarf/common/wsgi.py
+++ b/reddwarf/common/wsgi.py
@@ -310,16 +310,36 @@ class Fault(webob.exc.HTTPException):
 
         self.wrapped_exc = exception
 
+    @staticmethod
+    def _get_error_name(exc):
+        # Displays a Red Dwarf specific error name instead of a webob exc name.
+        named_exceptions = {
+            'HTTPBadRequest': 'badRequest',
+            'HTTPUnauthorized': 'unauthorized',
+            'HTTPForbidden': 'forbidden',
+            'HTTPNotFound': 'itemNotFound',
+            'HTTPMethodNotAllowed': 'badMethod',
+            'HTTPRequestEntityTooLarge': 'overLimit',
+            'HTTPUnsupportedMediaType': 'badMediaType',
+            'HTTPInternalServerError': 'instanceFault',
+            'HTTPNotImplemented': 'notImplemented',
+            'HTTPServiceUnavailable': 'serviceUnavailable',
+        }
+        name = exc.__class__.__name__
+        if name in named_exceptions:
+            return named_exceptions[name]
+        # If the exception isn't in our list, at least strip off the
+        # HTTP from the name, and then drop the case on the first letter.
+        name = name.split("HTTP").pop()
+        name = name[:1].lower() + name[1:]
+        return name
+
     @webob.dec.wsgify(RequestClass=Request)
     def __call__(self, req):
         """Generate a WSGI response based on the exception passed to ctor."""
 
         # Replace the body with fault details.
-        fault_name = self.wrapped_exc.__class__.__name__
-        if fault_name.startswith("HTTP"):
-            fault_name = fault_name[4:]
-        lower = lambda s: s[:1].lower() + s[1:]
-        fault_name = lower(fault_name)
+        fault_name = Fault._get_error_name(self.wrapped_exc)
         fault_data = {
             fault_name: {
                 'code': self.wrapped_exc.status_int,

--- a/reddwarf/instance/models.py
+++ b/reddwarf/instance/models.py
@@ -172,7 +172,7 @@ class SimpleInstance(object):
     def load(context, id):
         try:
             db_info = DBInstance.find_by(id=id)
-        except rd_exceptions.NotFound:
+        except ModelNotFoundError:
             raise rd_exceptions.NotFound(uuid=id)
         service_status = InstanceServiceStatus.find_by(instance_id=id)
         LOG.info("service status=%s" % service_status)

--- a/reddwarf/instance/service.py
+++ b/reddwarf/instance/service.py
@@ -278,7 +278,7 @@ class InstanceController(BaseController):
         We are going to check that volume resizing data is present.
         """
         if 'size' not in volume:
-            raise rd_exceptions.BadRequest(
+            raise exception.BadRequest(
                 "Missing 'size' property of 'volume' in request body.")
         InstanceController._validate_volume_size(volume['size'])
 


### PR DESCRIPTION
Preserves our contracted error response names by mapping webob exceptions to our named errors.

Also repairs references to rd_exceptions that were missed in a refactor.
