### PR TITLE
Checks for an empty body in action requests and bottoms out appropriately

### DIFF
--- a/reddwarf/instance/service.py
+++ b/reddwarf/instance/service.py
@@ -106,6 +106,8 @@ class InstanceController(BaseController):
         LOG.info("req : '%s'\n\n" % req)
         LOG.info("Comitting an ACTION again instance %s for tenant '%s'"
                  % (id, tenant_id))
+        if not body:
+            raise exception.BadRequest(_("Invalid request body."))
         context = req.environ[wsgi.CONTEXT_KEY]
         instance = models.Instance.load(context, id)
         _actions = {


### PR DESCRIPTION
I figure handing an empty body to actions is an error, so we'd better throw one.
