### PR TITLE
Fixing DNS hostname code to save info to DB in taskmanager.

### DIFF
--- a/reddwarf/dns/manager.py
+++ b/reddwarf/dns/manager.py
@@ -71,18 +71,15 @@ class DnsManager(object):
         if entry:
             self.driver.delete_entry(entry.name, entry.type)
 
-    def update_hostname(self, instance):
+    def determine_hostname(self, instance_id):
         """
         Create the hostname field based on the instance id.
-        Use instance by default
+        Use instance by default.
         """
-        dns_support = config.Config.get('reddwarf_dns_support', 'False')
-        LOG.debug(_("reddwarf dns support = %s") % dns_support)
-        if utils.bool_from_string(dns_support):
-            entry = self.entry_factory.create_entry(instance.id)
-            instance.hostname = entry.name
-            instance.save()
-            LOG.debug("Saved the hostname as %s " % instance.hostname)
+        entry = self.entry_factory.create_entry(instance_id)
+        if entry:
+            return entry.name
         else:
-            instance.hostname = instance.name
-            instance.save()
+            return None
+
+

--- a/reddwarf/instance/views.py
+++ b/reddwarf/instance/views.py
@@ -93,7 +93,7 @@ class InstanceDetailView(InstanceView):
 
         dns_support = config.Config.get("reddwarf_dns_support", 'False')
         if utils.bool_from_string(dns_support):
-            result['hostname'] = self.instance.hostname
+            result['instance']['hostname'] = self.instance.hostname
 
         if self.add_addresses:
             ip = get_ip_address(self.instance.addresses)


### PR DESCRIPTION
- Got rid of update_hostname method.
- Return the entry.name in the create_instance_entry method, and now use that value to update the DB in the taskmanager code.
- Fixed hostname bug in the views.
