### PR TITLE
Delete the guest queue when deleting an instance.

### DIFF
--- a/reddwarf/guestagent/api.py
+++ b/reddwarf/guestagent/api.py
@@ -77,6 +77,10 @@ class API(object):
             LOG.error(e)
             raise exception.GuestError(original_message=str(e))
 
+    def delete_queue(self):
+        """Deletes the queue."""
+        rpc.delete_queue(self.context, self._get_routing_key())
+
     def _get_routing_key(self):
         """Create the routing key based on the container id"""
         return "guestagent.%s" % self.id

--- a/reddwarf/rpc/__init__.py
+++ b/reddwarf/rpc/__init__.py
@@ -99,6 +99,11 @@ def cast_with_consumer(context, topic, msg):
     return _get_impl().cast_with_consumer(context, topic, msg)
 
 
+def delete_queue(context, topic):
+    """Deletes the queue."""
+    return _get_impl().delete_queue(context, topic)
+
+
 def fanout_cast(context, topic, msg):
     """Broadcast a remote method invocation with no return.
 

--- a/reddwarf/rpc/impl_kombu.py
+++ b/reddwarf/rpc/impl_kombu.py
@@ -673,6 +673,17 @@ def cast_with_consumer(context, topic, msg):
     return rpc_amqp.cast_with_consumer(context, topic, msg, Connection.pool)
 
 
+def delete_queue(context, topic):
+    LOG.debug("Deleting queue with name %s." % topic)
+    with rpc_amqp.ConnectionContext(Connection.pool) as conn:
+        channel = conn.channel
+        durable = config.Config.get('rabbit_durable_queues', False)
+        queue = kombu.entity.Queue(name=topic, channel=channel,
+                                   auto_delete=False, exclusive=False,
+                                   durable=durable)
+        queue.delete()
+
+
 def fanout_cast(context, topic, msg):
     """Sends a message on a fanout exchange without waiting for a response."""
     return rpc_amqp.fanout_cast(context, topic, msg, Connection.pool)

--- a/reddwarf/taskmanager/models.py
+++ b/reddwarf/taskmanager/models.py
@@ -222,6 +222,9 @@ class BuiltInstanceTasks(BuiltInstance):
                    time_out=int(config.Config.get('server_delete_time_out')))
         # If time out occurs, the instance task is stuck in DELETING.
         LOG.debug("Setting instance %s to deleted..." % self.id)
+        # Delete guest queue.
+        guest = self.get_guest()
+        guest.delete_queue()
         self.update_db(task_status=InstanceTasks.NONE)
         self.update_db(deleted=True, deleted_at=datetime.now())
 


### PR DESCRIPTION
- Added a "delete_queue" method to the guestagent.api.
- Added a "delete_queue" method to reddwarf.rpc, which is currently only implemented in kombu.
