### PR TITLE
Adding tox support to Reddwarf.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ covhtml/
 .DS_Store
 host-syslog.log
 tags
+.tox

--- a/bin/reddwarf-manage
+++ b/bin/reddwarf-manage
@@ -84,7 +84,19 @@ class Commands(object):
         image.image_id = image_id
         db_api.save(image)
 
-    _commands = ['db_sync', 'db_upgrade', 'db_downgrade', 'image_update']
+    def db_wipe(self, repo_path, service_name, image_id):
+        """Drops the database and recreates it."""
+        from reddwarf.instance import models
+        from reddwarf.db.sqlalchemy import session
+        db_api.drop_db(self.conf)
+        self.db_sync(repo_path)
+        # Sets up database engine, so the next line will work...
+        session.configure_db(self.conf)
+        models.ServiceImage.create(service_name=service_name,
+                                   image_id=image_id)
+
+    _commands = ['db_sync', 'db_upgrade', 'db_downgrade', 'db_wipe',
+                 'image_update']
 
     @classmethod
     def has(cls, command_name):

--- a/etc/reddwarf/reddwarf.conf.test
+++ b/etc/reddwarf/reddwarf.conf.test
@@ -104,7 +104,7 @@ pipeline = faultwrapper tokenauth authorization contextwrapper extensions reddwa
 paste.filter_factory = reddwarf.common.extensions:factory
 
 [filter:tokenauth]
-paste.filter_factory = keystone.middleware.auth_token:filter_factory
+paste.filter_factory = reddwarf.tests.fakes.keystone:filter_factory
 service_protocol = http
 service_host = 127.0.0.1
 service_port = 5000

--- a/reddwarf/common/auth.py
+++ b/reddwarf/common/auth.py
@@ -68,8 +68,10 @@ class TenantBasedAuth(object):
             LOG.debug(_("Authorized tenant '%(tenant_id)s' request: "
                       "%(request)s") % locals())
             return True
-        raise webob.exc.HTTPForbidden(_("User with tenant id %s cannot "
-                                        "access this resource") % tenant_id)
+        msg = _("User with tenant id %s cannot access this resource") \
+              % tenant_id
+        LOG.debug(msg)
+        raise webob.exc.HTTPForbidden(msg)
 
 
 def admin_context(f):

--- a/reddwarf/tests/fakes/keystone.py
+++ b/reddwarf/tests/fakes/keystone.py
@@ -1,0 +1,89 @@
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+
+# Copyright 2010-2012 OpenStack LLC.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import re
+
+
+TOKENS = {
+    "abcde"
+}
+
+
+class AuthProtocol(object):
+
+    def __init__(self, app, conf):
+        self.conf = conf
+        self.app = app
+
+    def __call__(self, env, start_response):
+        token = self._get_user_token_from_header(env)
+        user_headers = self._get_info_from_token(token)
+        self._add_headers(env, user_headers)
+        return self.app(env, start_response)
+
+    def _header_to_env_var(self, key):
+        """Convert header to wsgi env variable.
+
+        :param key: http header name (ex. 'X-Auth-Token')
+        :return wsgi env variable name (ex. 'HTTP_X_AUTH_TOKEN')
+
+        """
+        return 'HTTP_%s' % key.replace('-', '_').upper()
+
+    def _add_headers(self, env, headers):
+        """Add http headers to environment."""
+        for (k, v) in headers.iteritems():
+            env_key = self._header_to_env_var(k)
+            env[env_key] = v
+
+    def get_admin_token(self):
+        return "ABCDEF0123456789"
+
+    def _get_info_from_token(self, token):
+        if token.startswith("admin"):
+            role = "admin,%s" % token
+        else:
+            role = token
+        return {
+            'X_IDENTITY_STATUS': 'Confirmed',
+            'X_TENANT_ID': token,
+            'X_TENANT_NAME': token,
+            'X_USER_ID': token,
+            'X_USER_NAME': token,
+            'X_ROLE': role,
+        }
+
+    def _get_header(self, env, key, default=None):
+        # Copied from keystone.
+        env_key = self._header_to_env_var(key)
+        return env.get(env_key, default)
+
+    def _get_user_token_from_header(self, env):
+        token = self._get_header(env, 'X-Auth-Token',
+                                 self._get_header(env, 'X-Storage-Token'))
+        if token:
+            return token
+        else:
+            raise RuntimeError('Unable to find token in headers')
+
+def filter_factory(global_conf, **local_conf):
+    """Fakes a keystone filter."""
+    conf = global_conf.copy()
+    conf.update(local_conf)
+
+    def auth_filter(app):
+        return AuthProtocol(app, conf)
+    return auth_filter

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,16 @@
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 
-# Copyright 2010 United States Government as represented by the
-# Administrator of the National Aeronautics and Space Administration.
-# All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
 #
-#    Licensed under the Apache License, Version 2.0 (the "License"); you may
-#    not use this file except in compliance with the License. You may obtain
-#    a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-#    License for the specific language governing permissions and limitations
-#    under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
 
 import gettext
 import os

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,38 @@
+# To run a specific environment in tox, use the "-e" cmd line flag.
+# For example, to run pep8, use:
+# tox -e pep8
+
+[tox]
+envlist = py26, py27
+
+[testenv:pep8]
+# Tests pep8 compliance.
+deps = pep8==1.1
+commands = pep8 --repeat --show-source --exclude=.venv,.tox,dist,doc .
+
+
+[testenv:fake-mode]
+# Fakes Nova, the guest, and other external dependencies to stand up a
+# otherwise valid service api that can be used to test most code paths.
+deps =
+    eventlet
+    factory_boy
+    httplib2
+    iso8601
+    kombu==1.5.1
+    lxml
+    mox
+    netaddr
+    paste
+    PasteDeploy
+    python-novaclient
+    routes
+    sphinx
+    SQLAlchemy
+    sqlalchemy-migrate
+    WebOb
+    webtest
+commands =
+
+    {envpython} bin/reddwarf-manage --config-file=etc/reddwarf/reddwarf.conf.test db_wipe reddwarf_test.sqlite mysql fake
+    {envpython} bin/reddwarf-server --config-file=etc/reddwarf/reddwarf.conf.test repo_path=reddwarf_test.sqlite


### PR DESCRIPTION
- Changed reddwarf.conf.test to reflect local mode.
- Updated fake keystone. Any token is treated as the tenant ID, and any tenant id starting with "admin" is treated as an admin.
