### PR TITLE
Since the comparison inside is <=, the message ought to reflect that.

### DIFF
--- a/reddwarf/instance/models.py
+++ b/reddwarf/instance/models.py
@@ -455,8 +455,8 @@ class Instance(BuiltInstance):
             raise exception.BadRequest("Instance %s has no volume." % self.id)
         old_size = self.volume_size
         if int(new_size) <= old_size:
-            raise exception.BadRequest("The new volume 'size' cannot be "
-                        "less than the current volume size of '%s'" % old_size)
+            raise exception.BadRequest("The new volume 'size' must be larger "
+                        "than the current volume size of '%s'" % old_size)
         # Set the task to Resizing before sending off to the taskmanager
         self.update_db(task_status=InstanceTasks.RESIZING)
         task_api.API(self.context).resize_volume(new_size, self.id)


### PR DESCRIPTION
You can't resize a volume to the same size; this error message acknowledges that.
