### PR TITLE
Improved ability to run fake mode in CI environments.

### DIFF
--- a/bin/reddwarf-server
+++ b/bin/reddwarf-server
@@ -50,19 +50,14 @@ def create_options(parser):
         type=int,
         help="Port the Reddwarf API host listens on. "
              "Default: %default")
+    parser.add_option("-f", '--fork', action="store_true", dest="fork")
+    parser.add_option('--pid_file', dest="pid_file", default=".pid")
     config.add_common_options(parser)
     config.add_log_options(parser)
 
 
-if __name__ == '__main__':
-    oparser = optparse.OptionParser(version="%%prog %s"
-    % version.version_string())
-    create_options(oparser)
-    (options, args) = config.parse_options(oparser)
+def run_server(app, port):
     try:
-        config.Config.load_paste_config('reddwarf', options, args)
-        conf, app = config.Config.load_paste_app('reddwarf', options, args)
-        db_api.configure_db(conf)
         server = wsgi.Server()
         server.start(app, int(options.get('port') or conf['bind_port']),
             conf['bind_host'])
@@ -71,3 +66,26 @@ if __name__ == '__main__':
         import traceback
         print traceback.format_exc()
         sys.exit("ERROR: %s" % error)
+
+
+if __name__ == '__main__':
+    oparser = optparse.OptionParser(version="%%prog %s"
+                                    % version.version_string())
+    create_options(oparser)
+    (options, args) = config.parse_options(oparser)
+    config.Config.load_paste_config('reddwarf', options, args)
+    conf, app = config.Config.load_paste_app('reddwarf', options, args)
+    db_api.configure_db(conf)
+    port = int(options.get('port') or conf['bind_port'])
+    if options['fork']:
+        pid = os.fork()
+        if pid == 0:
+            run_server(app, port)
+        else:
+            print("Starting server:%s" % pid)
+            pid_file = options.get('pid_file', '.pid')
+            with open(pid_file, 'w') as f:
+                f.write(str(pid))
+    else:
+        run_server(app, port)
+

--- a/bin/start_server.sh
+++ b/bin/start_server.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Arguments: Use --pid_file to specify a pid file location.
+tox -e fake-mode
+
+function run() {
+    .tox/fake-mode/bin/python $@
+}
+run bin/reddwarf-manage \
+    --config-file=etc/reddwarf/reddwarf.conf.test db_wipe \
+    reddwarf_test.sqlite mysql fake
+run bin/reddwarf-server \
+    --fork --config-file=etc/reddwarf/reddwarf.conf.test \
+    repo_path=reddwarf_test.sqlite $@
+

--- a/bin/stop_server.sh
+++ b/bin/stop_server.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Arguments: if given the first argument is the location of a pid file.
+if [ $# -lt 1 ]; then
+    export PID_FILE=".pid"
+else
+    export PID_FILE=$1
+fi
+if [ -f $PID_FILE ];
+then
+    cat $PID_FILE
+    kill `cat $PID_FILE`
+    echo "Stopping server."
+    rm $PID_FILE
+else
+    echo "pid file not found."
+fi

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,4 @@ deps =
     WebOb
     webtest
 commands =
-
-    {envpython} bin/reddwarf-manage --config-file=etc/reddwarf/reddwarf.conf.test db_wipe reddwarf_test.sqlite mysql fake
-    {envpython} bin/reddwarf-server --config-file=etc/reddwarf/reddwarf.conf.test repo_path=reddwarf_test.sqlite
+    {envpython} {posargs:DEFAULTS}


### PR DESCRIPTION
- The reddwarf-server script can now fork itself and save it's pid.
- Changed the tox.ini to not start the fake mode server. Now, two new
  bin scripts start and stop the server. This should make it easier to
  run in CI environments.
