### PR TITLE
PEP8 fixes, mostly whitespace and line-length changes.

### DIFF
--- a/reddwarf/common/api.py
+++ b/reddwarf/common/api.py
@@ -22,7 +22,8 @@ from reddwarf.common import wsgi
 from reddwarf.versions import VersionsController
 from reddwarf.flavor.service import FlavorController
 from reddwarf.instance.service import InstanceController
-from reddwarf.extensions.mgmt.host.instance.service import HostInstanceController
+from reddwarf.extensions.mgmt.host.instance.service import (
+                                                        HostInstanceController)
 
 
 class API(wsgi.Router):

--- a/reddwarf/common/exception.py
+++ b/reddwarf/common/exception.py
@@ -157,10 +157,12 @@ class BadValue(ReddwarfError):
 
 
 class PollTimeOut(ReddwarfError):
+
     message = _("Polling request timed out.")
 
 
 class Forbidden(ReddwarfError):
+
     message = _("User does not have admin privileges.")
 
 
@@ -172,6 +174,7 @@ class InvalidModelError(ReddwarfError):
 class ModelNotFoundError(NotFound):
 
     message = _("Not Found")
+
 
 class UpdateGuestError(ReddwarfError):
 

--- a/reddwarf/common/manager.py
+++ b/reddwarf/common/manager.py
@@ -45,4 +45,3 @@ class ManagerAPI(object):
 
     def _fake_cast(self, method_name, **kwargs):
         pass
-

--- a/reddwarf/common/wsgi.py
+++ b/reddwarf/common/wsgi.py
@@ -48,21 +48,26 @@ LOG = logging.getLogger('reddwarf.common.wsgi')
 
 XMLNS = 'http://docs.openstack.org/database/api/v1.0'
 CUSTOM_PLURALS_METADATA = {'databases': '', 'users': ''}
-CUSTOM_SERIALIZER_METADATA =  \
-{   'instance': {'status': '', 'hostname': '',
-                 'id': '', 'name': '', 'created': '',
-                 'updated': '', 'host': '',
-                 'server_id':'',
+CUSTOM_SERIALIZER_METADATA = {
+    'instance': {'status': '',
+                 'hostname': '',
+                 'id': '',
+                 'name': '',
+                 'created': '',
+                 'updated': '',
+                 'host': '',
+                 'server_id': '',
                  #mgmt/instance
-                 'local_id':'',
-                 'task_description':'',
-                 'deleted':'',
-                 'deleted_at':'',
-                 'tenant_id':'',
+                 'local_id': '',
+                 'task_description': '',
+                 'deleted': '',
+                 'deleted_at': '',
+                 'tenant_id': '',
                  },
-    'volume': {'size': '', 'used': '',
-              #mgmt/instance
-               'id':'',
+    'volume': {'size': '',
+               'used': '',
+               #mgmt/instance
+               'id': '',
               },
     'flavor': {'id': '', 'ram': '', 'name': ''},
     'link': {'href': '', 'rel': ''},
@@ -70,23 +75,22 @@ CUSTOM_SERIALIZER_METADATA =  \
     'user': {'name': '', 'password': ''},
     'account': {'id': ''},
     # mgmt/host
-    'host':{'instanceCount':'', 'name':'', 'usedRAM':'', 'totalRAM':'',
-            'percentUsed':''},
+    'host': {'instanceCount': '', 'name': '', 'usedRAM': '', 'totalRAM': '',
+            'percentUsed': ''},
     # mgmt/storage
-    'capacity': {'available':'', 'total':''},
-    'provision': {'available':'', 'total':'', 'percent':''},
-    'device': {'used':'', 'name':'', 'type':''},
+    'capacity': {'available': '', 'total': ''},
+    'provision': {'available': '', 'total': '', 'percent': ''},
+    'device': {'used': '', 'name': '', 'type': ''},
     # mgmt/account
-    'account': {'id':'', 'num_instances':''},
+    'account': {'id': '', 'num_instances': ''},
     #mgmt/instance
-    'guest_status': {'state_description':''},
+    'guest_status': {'state_description': ''},
     #mgmt/instance/diagnostics
-    'diagnostics':{'vmHwm':'', 'vmPeak':'', 'vmSize':'', 'threads':'',
-                   'version':'', 'vmRss':'', 'fdSize':''},
+    'diagnostics': {'vmHwm': '', 'vmPeak': '', 'vmSize': '', 'threads': '',
+                   'version': '', 'vmRss': '', 'fdSize': ''},
     #mgmt/instance/root
-    'root_history':{'enabled':'', 'id':'', 'user':''},
+    'root_history': {'enabled': '', 'id': '', 'user': ''},
 }
-
 
 
 def versioned_urlmap(*args, **kwargs):
@@ -228,8 +232,8 @@ class Resource(openstack_wsgi.Resource):
         """Flattens values of keys and inverts keys and values.
 
         Example:
-        {'x':[1,2,3],'y':[4,5,6]} converted to
-        {1:'x',2:'x',3:'x',4:'y',5:'y',6:'y'}
+        {'x': [1, 2, 3], 'y': [4, 5, 6]} converted to
+        {1: 'x', 2: 'x', 3: 'x', 4: 'y', 5: 'y', 6: 'y'}
 
         """
         inverted_dict = {}
@@ -252,7 +256,7 @@ class Resource(openstack_wsgi.Resource):
             # or pass them back if they're webobs.
             if not isinstance(action_result, webob.Response):
                 LOG.error("unserializable result detected! "
-                          "Exception type: %s Message:%s" % (type(ex), ex))
+                          "Exception type: %s Message: %s" % (type(ex), ex))
                 raise
 
 
@@ -368,11 +372,11 @@ class ReddwarfXMLDictSerializer(openstack_wsgi.XMLDictSerializer):
             elif root_key is None:
                 root_key = key
             else:
-                msg = "Xml issue: multiple root keys found in dict!:%s" % data
+                msg = "Xml issue: multiple root keys found in dict!: %s" % data
                 LOG.error(msg)
                 raise RuntimeError(msg)
         if root_key is None:
-            msg = "Missing root key in dict:%s" % data
+            msg = "Missing root key in dict: %s" % data
             LOG.error(msg)
             raise RuntimeError(msg)
         doc = minidom.Document()
@@ -392,8 +396,6 @@ class ReddwarfXMLDictSerializer(openstack_wsgi.XMLDictSerializer):
             metadata,
             nodename,
             data)
-
-
 
 
 class ReddwarfResponseSerializer(openstack_wsgi.ResponseSerializer):

--- a/reddwarf/db/sqlalchemy/migrate_repo/versions/009_add_deleted_flag_to_instances.py
+++ b/reddwarf/db/sqlalchemy/migrate_repo/versions/009_add_deleted_flag_to_instances.py
@@ -38,4 +38,3 @@ def downgrade(migrate_engine):
     instances = Table('instances', meta, autoload=True)
     instances.drop_column('deleted')
     instances.drop_column('deleted_at')
-

--- a/reddwarf/dns/manager.py
+++ b/reddwarf/dns/manager.py
@@ -81,5 +81,3 @@ class DnsManager(object):
             return entry.name
         else:
             return None
-
-

--- a/reddwarf/extensions/account/service.py
+++ b/reddwarf/extensions/account/service.py
@@ -51,4 +51,3 @@ class AccountController(wsgi.Controller):
         LOG.info(_("Showing all accounts with instances for '%s'") % tenant_id)
         accounts_summary = models.AccountsSummary.load()
         return wsgi.Result(views.AccountsView(accounts_summary).data(), 200)
-

--- a/reddwarf/extensions/mgmt.py
+++ b/reddwarf/extensions/mgmt.py
@@ -21,7 +21,8 @@ from reddwarf.common import extensions
 from reddwarf.common import wsgi
 from reddwarf.extensions.mgmt.instances.service import MgmtInstanceController
 from reddwarf.extensions.mgmt.host.service import HostController
-from reddwarf.extensions.mgmt.host.instance.service import HostInstanceController
+from reddwarf.extensions.mgmt.host.instance.service import (
+                                                        HostInstanceController)
 from reddwarf.extensions.mgmt.volume.service import StorageController
 
 

--- a/reddwarf/extensions/mgmt/host/views.py
+++ b/reddwarf/extensions/mgmt/host/views.py
@@ -23,8 +23,8 @@ class HostView(object):
 
     def data(self):
         return {
-           'instanceCount':self.host.instance_count,
-           'name':self.host.name
+           'instanceCount': self.host.instance_count,
+           'name': self.host.name
         }
 
 
@@ -34,7 +34,7 @@ class HostDetailedView(object):
         self.host = host
 
     def data(self):
-        return {'host':{
+        return {'host': {
             'instances': self.host.instances,
             'name': self.host.name,
             'percentUsed': self.host.percent_used,
@@ -49,5 +49,5 @@ class HostsView(object):
         self.hosts = hosts
 
     def data(self):
-        data = [ HostView(host).data() for host in self.hosts ]
+        data = [HostView(host).data() for host in self.hosts]
         return {'hosts': data}

--- a/reddwarf/extensions/mgmt/instances/models.py
+++ b/reddwarf/extensions/mgmt/instances/models.py
@@ -128,8 +128,9 @@ class MgmtInstances(imodels.Instances):
         if context is None:
             raise TypeError("Argument context not defined.")
         find_server = imodels.create_server_list_matcher(servers)
-        instances = imodels.Instances._load_servers_status(load_instance, context,
-                                                     db_infos, find_server)
+        instances = imodels.Instances._load_servers_status(load_instance,
+                                                           context, db_infos,
+                                                           find_server)
         _load_servers(instances, find_server)
         return instances
 
@@ -144,5 +145,3 @@ def _load_servers(instances, find_server):
         except Exception as ex:
             LOG.error(ex)
     return instances
-
-

--- a/reddwarf/extensions/mgmt/instances/service.py
+++ b/reddwarf/extensions/mgmt/instances/service.py
@@ -50,7 +50,7 @@ class MgmtInstanceController(InstanceController):
         if deleted_q in ['true']:
             deleted = True
         elif deleted_q in ['false']:
-            deleted=False
+            deleted = False
         try:
             instances = models.load_mgmt_instances(context, deleted=deleted)
         except nova_exceptions.ClientException, e:

--- a/reddwarf/extensions/mgmt/instances/views.py
+++ b/reddwarf/extensions/mgmt/instances/views.py
@@ -61,9 +61,10 @@ class MgmtInstanceDetailView(MgmtInstanceView):
 
     def __init__(self, instance, req, add_addresses=False,
                  add_volumes=False, root_history=None):
+        add_a = add_addresses
         super(MgmtInstanceDetailView, self).__init__(instance,
                                                      req=req,
-                                                     add_addresses=add_addresses,
+                                                     add_addresses=add_a,
                                                      add_volumes=add_volumes)
         self.root_history = root_history
 
@@ -71,9 +72,8 @@ class MgmtInstanceDetailView(MgmtInstanceView):
         result = super(MgmtInstanceDetailView, self).data()
         if self.instance.server is not None:
             server = self.instance.server
-            result['instance']['server'].update({
-                'addresses':server.addresses
-                })
+            result['instance']['server'].update(
+                                         {'addresses': server.addresses})
         if self.root_history:
             result['instance']['root_enabled'] = self.root_history.created
             result['instance']['root_enabled_by'] = self.root_history.user
@@ -89,15 +89,16 @@ class MgmtInstanceDetailView(MgmtInstanceView):
             }
         else:
             result['instance']['volume'] = None
-        result['instance']['guest_status'] = {
-            "state_description": self.instance.service_status.status.description
-        }
+        description = self.instance.service_status.status.description
+        result['instance']['guest_status'] = {state_description": description}
         return result
+
 
 class MgmtInstancesView(object):
     """Shows a list of MgmtInstance objects."""
 
-    def __init__(self, instances, req=None, add_addresses= False, add_volumes=False):
+    def __init__(self, instances, req=None, add_addresses=False,
+                 add_volumes=False):
         self.instances = instances
         self.req = req
         self.add_addresses = add_addresses

--- a/reddwarf/extensions/mgmt/volume/service.py
+++ b/reddwarf/extensions/mgmt/volume/service.py
@@ -36,4 +36,3 @@ class StorageController(wsgi.Controller):
         context = req.environ[wsgi.CONTEXT_KEY]
         storages = models.StorageDevices.load(context)
         return wsgi.Result(views.StoragesView(storages).data(), 200)
-

--- a/reddwarf/instance/models.py
+++ b/reddwarf/instance/models.py
@@ -86,7 +86,6 @@ def load_simple_instance_server_status(context, db_info):
             db_info.addresses = {}
 
 
-
 # If the compute server is in any of these states we can't perform any
 # actions (delete, resize, etc).
 SERVER_INVALID_ACTION_STATUSES = ["BUILD", "REBOOT", "REBUILD", "RESIZE"]
@@ -422,7 +421,6 @@ class Instance(BuiltInstance):
         task_api.API(context).create_instance(db_info.id, name, flavor_id,
             flavor.ram, image_id, databases, users, service_type, volume_size)
 
-
         return SimpleInstance(context, db_info, service_status)
 
     def resize_flavor(self, new_flavor_id):
@@ -559,7 +557,7 @@ class Instances(object):
                         server = find_server(db.id, db.compute_instance_id)
                         db.server_status = server.status
                     except exception.ComputeInstanceNotFound:
-                        db.server_status = "SHUTDOWN" # Fake it...
+                        db.server_status = "SHUTDOWN"  # Fake it...
                 #TODO(tim.simpson): End of hack.
 
                 #volumes = find_volumes(server.id)

--- a/reddwarf/instance/service.py
+++ b/reddwarf/instance/service.py
@@ -128,7 +128,7 @@ class InstanceController(wsgi.Controller):
 
     def _action_reset_password(self, instance, body):
         raise webob.exc.HTTPNotImplemented()
-    
+
     def index(self, req, tenant_id):
         """Return all instances."""
         LOG.info(_("req : '%s'\n\n") % req)

--- a/reddwarf/taskmanager/manager.py
+++ b/reddwarf/taskmanager/manager.py
@@ -59,10 +59,12 @@ class TaskManager(service.Manager):
 
     def delete_instance(self, context, instance_id):
         try:
-            instance_tasks = models.BuiltInstanceTasks.load(context, instance_id)
+            instance_tasks = models.BuiltInstanceTasks.load(context,
+                                                            instance_id)
             instance_tasks.delete_async()
         except exception.UnprocessableEntity as upe:
-            instance_tasks = models.FreshInstanceTasks.load(context, instance_id)
+            instance_tasks = models.FreshInstanceTasks.load(context,
+                                                            instance_id)
             instance_tasks.delete_async()
 
     def create_instance(self, context, instance_id, name, flavor_id,

--- a/reddwarf/taskmanager/models.py
+++ b/reddwarf/taskmanager/models.py
@@ -288,6 +288,7 @@ class BuiltInstanceTasks(BuiltInstance):
                       % self.db_info.id)
             LOG.error(ex)
         # Poll until the server is gone.
+
         def server_is_finished():
             try:
                 server_id = self.db_info.compute_instance_id
@@ -302,7 +303,6 @@ class BuiltInstanceTasks(BuiltInstance):
 
         poll_until(server_is_finished, sleep_time=2,
                    time_out=int(config.Config.get('server_delete_time_out')))
-
 
     def resize_volume(self, new_size):
         LOG.debug("%s: Resizing volume for instance: %s to %r GB"
@@ -404,6 +404,7 @@ class BuiltInstanceTasks(BuiltInstance):
 
             # Poll nova until instance is active
             reboot_time_out = int(config.Config.get("reboot_time_out", 60 * 2))
+
             def update_server_info():
                 self._refresh_compute_server_info()
                 return self.server.status == 'ACTIVE'

--- a/reddwarf/tests/fakes/keystone.py
+++ b/reddwarf/tests/fakes/keystone.py
@@ -74,6 +74,7 @@ class AuthProtocol(object):
         else:
             raise RuntimeError('Unable to find token in headers')
 
+
 def filter_factory(global_conf, **local_conf):
     """Fakes a keystone filter."""
     conf = global_conf.copy()

--- a/reddwarf/tests/fakes/nova.py
+++ b/reddwarf/tests/fakes/nova.py
@@ -109,11 +109,11 @@ class FakeServer(object):
         self.next_local_id += 1
         info_vols = []
         for volume in self.volumes:
-            info_vols.append({'id':volume.id})
+            info_vols.append({'id': volume.id})
             volume.set_attachment(id)
         self.host = "fake_host"
 
-        self._info = {'os:volumes':info_vols}
+        self._info = {'os:volumes': info_vols}
 
     @property
     def addresses(self):
@@ -215,17 +215,19 @@ class FakeServers(object):
         return self.context.is_admin or \
                server.owner.tenant == self.context.tenant
 
-    def create(self, name, image_id, flavor_ref, files=None, block_device_mapping=None, volume=None):
+    def create(self, name, image_id, flavor_ref, files=None,
+               block_device_mapping=None, volume=None):
         id = "FAKE_%s" % uuid.uuid4()
         if volume:
-            volume = self.volumes.create(volume['size'], volume['name'], volume['description'])
+            volume = self.volumes.create(volume['size'], volume['name'],
+                                         volume['description'])
             while volume.status == "BUILD":
                 eventlet.sleep(0.1)
             if volume.status != "available":
                 LOG.info("volume status = %s" % volume.status)
                 raise nova_exceptions.ClientException("Volume was bad!")
             mapping = "%s::%s:%s" % (volume.id, volume.size, 1)
-            block_device_mapping = { 'vdb': mapping }
+            block_device_mapping = {'vdb': mapping}
             volumes = [volume]
         else:
             volumes = self._get_volumes_from_bdm(block_device_mapping)
@@ -300,7 +302,7 @@ class FakeRdServer(object):
     def __init__(self, server):
         self.server = server
         self.deleted = False
-        self.deleted_at = None # Not sure how to simulate "True" for this.
+        self.deleted_at = None  # Not sure how to simulate "True" for this.
         self.local_id = server._local_id
 
     def __getattr__(self, name):
@@ -488,8 +490,8 @@ class FakeAccounts(object):
     def get_instances(self, id):
         authorize(self.context)
 
-        servers =  [v for (k, v) in self.db.items()
-                                 if self._belongs_to_tenant(id, v.id)]
+        servers = [v for (k, v) in self.db.items()
+                   if self._belongs_to_tenant(id, v.id)]
         return FakeAccount(id, servers)
 
 
@@ -517,7 +519,7 @@ class FakeHost(object):
         """
         self.instances = []
         self.percentUsed = 0
-        self.totalRAM = 2004 #16384
+        self.totalRAM = 2004  # 16384
         self.usedRAM = 0
         for server in self.servers.list():
             self.instances.append({


### PR DESCRIPTION
The silliest thing is the long import lines. Normally I'd just ignore them, but for the sake of making `pep8` happy, I figured I'd knock them off using multi-line imports a la PEP 328.

The remaining PEP8 errors are deprecated raises, but those are only warnings; I figure at least we're free of errors for now.
