### PR TITLE
Now if DNS is unresponsive, it'll show up in the task manager.

### DIFF
--- a/reddwarf/common/remote.py
+++ b/reddwarf/common/remote.py
@@ -27,6 +27,20 @@ def create_dns_client(context):
     return DnsManager()
 
 
+def create_dns_hostname_factory(context):
+    """Creates a function that given an ID, determines the hostname."""
+    from reddwarf.dns.manager import get_dns_instance_entry_factory
+    factory = get_dns_instance_entry_factory()
+    def determine_hostname(instance_id):
+        entry = factory.create_entry(instance_id)
+        if entry:
+            return entry.name
+        else:
+            return None
+
+    return determine_hostname
+
+
 def create_guest_client(context, id):
     from reddwarf.guestagent.api import API
     return API(context, id)

--- a/reddwarf/dns/manager.py
+++ b/reddwarf/dns/manager.py
@@ -26,22 +26,28 @@ from reddwarf.common import config
 LOG = logging.getLogger(__name__)
 
 
+def get_dns_driver():
+    return config.Config.get("dns_driver", "reddwarf.dns.driver.DnsDriver")
+
+
+def get_dns_instance_entry_factory():
+    return config.Config.get(
+        'dns_instance_entry_factory',
+        'reddwarf.dns.driver.DnsInstanceEntryFactory')
+
+
 class DnsManager(object):
     """Handles associating DNS to and from IPs."""
 
     def __init__(self, dns_driver=None, dns_instance_entry_factory=None,
                  *args, **kwargs):
         if not dns_driver:
-            dns_driver = config.Config.get(
-                "dns_driver",
-                "reddwarf.dns.driver.DnsDriver")
+            dns_driver = get_dns_driver()
         dns_driver = utils.import_object(dns_driver)
         self.driver = dns_driver()
 
         if not dns_instance_entry_factory:
-            dns_instance_entry_factory = config.Config.get(
-                'dns_instance_entry_factory',
-                'reddwarf.dns.driver.DnsInstanceEntryFactory')
+            dns_instance_entry_factory = get_dns_instance_entry_factory()
         entry_factory = utils.import_object(dns_instance_entry_factory)
         self.entry_factory = entry_factory()
 

--- a/reddwarf/instance/models.py
+++ b/reddwarf/instance/models.py
@@ -26,7 +26,7 @@ from novaclient import exceptions as nova_exceptions
 from reddwarf.common import config
 from reddwarf.common import exception
 from reddwarf.common import utils
-from reddwarf.common.remote import create_dns_client
+from reddwarf.common.remote import create_dns_hostname_factory
 from reddwarf.common.remote import create_guest_client
 from reddwarf.common.remote import create_nova_client
 from reddwarf.common.remote import create_nova_volume_client
@@ -409,8 +409,7 @@ class Instance(BuiltInstance):
 
         dns_support = config.Config.get("reddwarf_dns_support", 'False')
         if utils.bool_from_string(dns_support):
-            dns_client = create_dns_client(context)
-            hostname = dns_client.determine_hostname(db_info.id)
+            hostname = create_dns_hostname_factory(context)(db_info.id)
             db_info.hostname = hostname
             db_info.save()
 


### PR DESCRIPTION
- The API was authing to the DNS service unnecessarily and wasting time.
  This certain failures very hard to track. Now it simply creates the
  hostname without authing to a client which does not get used by the
  API process anyway.
