### PR TITLE
Get-host-by-name now uses RD instance status, not vm status, in instance...

### DIFF
--- a/reddwarf/extensions/mgmt/host/models.py
+++ b/reddwarf/extensions/mgmt/host/models.py
@@ -26,8 +26,9 @@ from reddwarf import db
 from reddwarf.common import config
 from reddwarf.common import exception
 from reddwarf.common import utils
-from reddwarf.instance import models as base_models
 from reddwarf.instance.models import DBInstance
+from reddwarf.instance.models import InstanceServiceStatus
+from reddwarf.instance.models import SimpleInstance
 from reddwarf.guestagent.db import models as guest_models
 from reddwarf.common.remote import create_guest_client
 from reddwarf.common.remote import create_nova_client
@@ -72,6 +73,10 @@ class DetailedHost(object):
                     compute_instance_id=instance['server_id'])
                 instance['id'] = db_info.id
                 instance['tenant_id'] = db_info.tenant_id
+                status = InstanceServiceStatus.find_by(
+                    instance_id=db_info.id)
+                instance_info = SimpleInstance(None, db_info, status)
+                instance['status'] = instance_info.status
             except exception.ReddwarfError as re:
                 LOG.error(re)
                 LOG.error("Compute Instance ID found with no associated RD "

--- a/reddwarf/taskmanager/models.py
+++ b/reddwarf/taskmanager/models.py
@@ -144,9 +144,6 @@ class FreshInstanceTasks(FreshInstance):
     def _log_and_raise(self, exc, message, task_status):
         LOG.error(message)
         LOG.error(exc)
-        tb = traceback.format_exc()
-        for line in tb:
-            LOG.error(line)
         LOG.error(traceback.format_exc())
         self.update_db(task_status=task_status)
         raise ReddwarfError(message=message)
@@ -231,14 +228,14 @@ class FreshInstanceTasks(FreshInstance):
                            mount_point=volume_info['mount_point'])
 
     def _create_dns_entry(self):
-        LOG.debug("%s: Creating dns entry for instance: %s"
-                  % (greenthread.getcurrent(), self.id))
-        dns_client = create_dns_client(self.context)
+        LOG.debug("%s: Creating dns entry for instance: %s" %
+                  (greenthread.getcurrent(), self.id))
         dns_support = config.Config.get("reddwarf_dns_support", 'False')
         LOG.debug(_("reddwarf dns support = %s") % dns_support)
 
-        nova_client = create_nova_client(self.context)
         if utils.bool_from_string(dns_support):
+            nova_client = create_nova_client(self.context)
+            dns_client = create_dns_client(self.context)
 
             def get_server():
                 c_id = self.db_info.compute_instance_id
@@ -263,6 +260,9 @@ class FreshInstanceTasks(FreshInstance):
             LOG.info("Creating dns entry...")
             dns_client.create_instance_entry(self.id,
                                              get_ip_address(server.addresses))
+        else:
+            LOG.debug("%s: DNS not enabled for instance: %s" %
+                      (greenthread.getcurrent(), self.id))
 
 
 class BuiltInstanceTasks(BuiltInstance):


### PR DESCRIPTION
... list.
Also notice a little bit of a logic change in create_dns_entry. If DNS isn't enabled, then save a little time by skipping out on creating a nova or DNS client.
