### PR TITLE
Uses the view to circumvent an error related to the assumption...

### DIFF
--- a/reddwarf/extensions/account/views.py
+++ b/reddwarf/extensions/account/views.py
@@ -45,8 +45,11 @@ class InstanceView(object):
         self.instance = instance
 
     def data(self):
+        server_host = None
+        if self.instance.server is not None:
+            server_host = self.instance.server.host
         return {'id': self.instance.id,
                 'status': self.instance.status,
                 'name': self.instance.name,
-                'host': self.instance.server.host,
+                'host': server_host,
                 }


### PR DESCRIPTION
that instance.server is present in the account views.
This is not true when an error during deletion removed the compute instance but not the reddwarf instance.
